### PR TITLE
add greater and less support for compatible elasticsearch lucene syntax 

### DIFF
--- a/internal/lex/lex.go
+++ b/internal/lex/lex.go
@@ -41,9 +41,13 @@ const (
 	TQuoted
 	TRegexp
 
+	// temporary
+
 	// precedance of operators. Order matters here. This might need to be abstracted
 	// to a grammar specific precedence but for now it is fine here.
 	TEqual
+	TGreater
+	TLess
 	TColon
 	TPlus
 	TMinus
@@ -62,8 +66,6 @@ const (
 	TTO
 	TLSquare
 	TRSquare
-	TGreater
-	TLess
 
 	// start and end operators
 	TEOF

--- a/internal/lex/lex.go
+++ b/internal/lex/lex.go
@@ -41,8 +41,6 @@ const (
 	TQuoted
 	TRegexp
 
-	// temporary
-
 	// precedance of operators. Order matters here. This might need to be abstracted
 	// to a grammar specific precedence but for now it is fine here.
 	TEqual

--- a/internal/lex/lext_test.go
+++ b/internal/lex/lext_test.go
@@ -35,6 +35,22 @@ func TestLex(t *testing.T) {
 				tok(TLiteral, "c"),
 			},
 		},
+		"negatives_in_elastic_comparison": {
+			in: "a:<-10 AND -b:>=20",
+			expected: []Token{
+				tok(TLiteral, "a"),
+				tok(TColon, ":"),
+				tok(TLess, "<"),
+				tok(TLiteral, "-10"),
+				tok(TAnd, "AND"),
+				tok(TMinus, "-"),
+				tok(TLiteral, "b"),
+				tok(TColon, ":"),
+				tok(TGreater, ">"),
+				tok(TEqual, "="),
+				tok(TLiteral, "20"),
+			},
+		},
 		"literals": {
 			in:       "abc",
 			expected: []Token{tok(TLiteral, "abc")},

--- a/parse_test.go
+++ b/parse_test.go
@@ -491,6 +491,15 @@ func TestParseLucene(t *testing.T) {
 				),
 			),
 		},
+		"test_elastic_greater_than_precedance": {
+			input: "a:>10 AND -b:<=-20",
+			want: expr.AND(
+				expr.GREATER("a", 10),
+				expr.MUSTNOT(
+					expr.LESSEQ("b", -20),
+				),
+			),
+		},
 	}
 
 	for name, tc := range tcs {
@@ -515,7 +524,11 @@ func TestParseLucene(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(got, &gotSerialized) {
-				t.Fatalf(errTemplate, "roundtrip serialization is not stable", tc.want, got)
+				// occasionally this test fails and the error message makes the test look like
+				// the want and got are equivalent. This is almost always an unexported var is different
+				// Using testify/require will show the error if it shows up
+				// require.Equal(t, tc.want, gotSerialized)
+				t.Fatalf(errTemplate, "roundtrip serialization is not stable", tc.want, gotSerialized)
 			}
 		})
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -46,6 +46,14 @@ func TestParseLucene(t *testing.T) {
 			input: "a:<=22",
 			want:  expr.LESSEQ("a", 22),
 		},
+		"basic_greater_less_with_number": {
+			input: "a:<22 AND b:>33",
+			want:  expr.AND(expr.LESS("a", 22), expr.GREATER("b", 33)),
+		},
+		"basic_greater_less_eq_with_number": {
+			input: "a:<=22 AND b:>=33",
+			want:  expr.AND(expr.LESSEQ("a", 22), expr.GREATEREQ("b", 33)),
+		},
 		"basic_wild_equal_with_*": {
 			input: "a:b*",
 			want:  expr.Eq("a", "b*"),

--- a/parse_test.go
+++ b/parse_test.go
@@ -30,6 +30,22 @@ func TestParseLucene(t *testing.T) {
 			input: "a:5",
 			want:  expr.Eq("a", 5),
 		},
+		"basic_greater_with_number": {
+			input: "a:>22",
+			want:  expr.GREATER("a", 22),
+		},
+		"basic_greater_eq_with_number": {
+			input: "a:>=22",
+			want:  expr.GREATEREQ("a", 22),
+		},
+		"basic_less_with_number": {
+			input: "a:<22",
+			want:  expr.LESS("a", 22),
+		},
+		"basic_less_eq_with_number": {
+			input: "a:<=22",
+			want:  expr.LESSEQ("a", 22),
+		},
 		"basic_wild_equal_with_*": {
 			input: "a:b*",
 			want:  expr.Eq("a", "b*"),

--- a/pkg/driver/base.go
+++ b/pkg/driver/base.go
@@ -9,19 +9,23 @@ import (
 // Shared is the shared set of render functions that can be used as a base and overriden
 // for each flavor of sql
 var Shared = map[expr.Operator]RenderFN{
-	expr.Literal: literal,
-	expr.And:     basicCompound(expr.And),
-	expr.Or:      basicCompound(expr.Or),
-	expr.Not:     basicWrap(expr.Not),
-	expr.Equals:  equals,
-	expr.Range:   rang,
-	expr.Must:    noop,                // must doesn't really translate to sql
-	expr.MustNot: basicWrap(expr.Not), // must not is really just a negation
-	expr.Fuzzy:   noop,
-	expr.Boost:   noop,
-	expr.Wild:    noop, // wildcard expressions can render as literal strings
-	expr.Regexp:  noop, // regexp expressions can render as literal strings
-	expr.Like:    like,
+	expr.Literal:   literal,
+	expr.And:       basicCompound(expr.And),
+	expr.Or:        basicCompound(expr.Or),
+	expr.Not:       basicWrap(expr.Not),
+	expr.Equals:    equals,
+	expr.Range:     rang,
+	expr.Must:      noop,                // must doesn't really translate to sql
+	expr.MustNot:   basicWrap(expr.Not), // must not is really just a negation
+	expr.Fuzzy:     noop,
+	expr.Boost:     noop,
+	expr.Wild:      noop, // wildcard expressions can render as literal strings
+	expr.Regexp:    noop, // regexp expressions can render as literal strings
+	expr.Like:      like,
+	expr.Greater:   greater,
+	expr.GreaterEq: greaterEq,
+	expr.Less:      less,
+	expr.LessEq:    lessEq,
 }
 
 // Base is the base driver that is embedded in each driver

--- a/pkg/driver/postgresql_test.go
+++ b/pkg/driver/postgresql_test.go
@@ -79,6 +79,22 @@ func TestSQLDriver(t *testing.T) {
 			input: expr.Rang("a", 1, "*", true),
 			want:  `a >= 1`,
 		},
+		"lt": {
+			input: expr.LESS("a", 10),
+			want:  `a < 10`,
+		},
+		"lte": {
+			input: expr.LESSEQ("a", 10),
+			want:  `a <= 10`,
+		},
+		"gt": {
+			input: expr.GREATER("a", 10),
+			want:  `a > 10`,
+		},
+		"gte": {
+			input: expr.GREATEREQ("a", 10),
+			want:  `a >= 10`,
+		},
 		"must_ignored": {
 			input: expr.MUST(expr.Eq("a", 1)),
 			want:  `a = 1`,

--- a/pkg/driver/renderfn.go
+++ b/pkg/driver/renderfn.go
@@ -34,6 +34,22 @@ func like(left, right string) (string, error) {
 	return fmt.Sprintf("%s SIMILAR TO %s", left, right), nil
 }
 
+func greater(left, right string) (string, error) {
+	return fmt.Sprintf("%s > %s", left, right), nil
+}
+
+func less(left, right string) (string, error) {
+	return fmt.Sprintf("%s < %s", left, right), nil
+}
+
+func greaterEq(left, right string) (string, error) {
+	return fmt.Sprintf("%s >= %s", left, right), nil
+}
+
+func lessEq(left, right string) (string, error) {
+	return fmt.Sprintf("%s <= %s", left, right), nil
+}
+
 // rang is more complicated than the others because it has to handle inclusive and exclusive ranges,
 // number and string ranges, and ranges that only have one bound
 func rang(left, right string) (string, error) {

--- a/pkg/lucene/expr/expression.go
+++ b/pkg/lucene/expr/expression.go
@@ -77,6 +77,22 @@ func Eq(a any, b any) *Expression {
 	return Expr(a, Equals, b)
 }
 
+func GREATER(a any, b any) *Expression {
+	return Expr(a, Greater, b)
+}
+
+func LESS(a any, b any) *Expression {
+	return Expr(a, Less, b)
+}
+
+func GREATEREQ(a any, b any) *Expression {
+	return Expr(a, GreaterEq, b)
+}
+
+func LESSEQ(a any, b any) *Expression {
+	return Expr(a, LessEq, b)
+}
+
 // LIKE creates a new fuzzy matching LIKE expression
 func LIKE(a any, b any) *Expression {
 	return Expr(a, Like, b)

--- a/pkg/lucene/expr/expression.go
+++ b/pkg/lucene/expr/expression.go
@@ -22,6 +22,13 @@ import (
 // 		id
 // 		[id TO id]
 
+// Added grammar to be compatible with elastic lucene
+// See https://www.elastic.co/guide/en/elasticsearch/reference/8.9/query-dsl-query-string-query.html#query-string-syntax
+//      E:>E
+//      E:>=E
+//      E:<E
+//      E:<=E
+
 // Expression is an interface over all the different types of expressions
 // that we can parse out of lucene
 type Expression struct {
@@ -54,6 +61,7 @@ func (e Expression) GoString() string {
 	if e.Op == Undefined {
 		return ""
 	}
+	fmt.Printf("E: %+v %+v %+v | %+v %+v\n", e.Left, e.Op, e.Right, e.boostPower, e.fuzzyDistance)
 	return renderers[e.Op](&e, true)
 }
 
@@ -186,7 +194,7 @@ func (c Column) GoString() string {
 // Expr creates a general new expression. The other public functions are just helpers that call this
 // function underneath.
 func Expr(left any, op Operator, right ...any) *Expression {
-	if isStringlike(left) && (op == Equals || op == Range) {
+	if isStringlike(left) && canOperateOnColumn(op) {
 		left = wrapInColumn(left)
 	}
 
@@ -313,7 +321,7 @@ func (e *Expression) UnmarshalJSON(data []byte) (err error) {
 	e.Op = fromString[c.Operator]
 
 	// if the left hand side is a string then it must be a column
-	if isStringlike(e.Left) && (e.Op == Equals || e.Op == Range) {
+	if isStringlike(e.Left) && canOperateOnColumn(e.Op) {
 		e.Left = wrapInColumn(e.Left)
 	}
 
@@ -438,6 +446,12 @@ func isStringlike(in any) bool {
 	}
 
 	return isStr
+}
+
+// canOperateOnColumn checks if an operator can be applied to a column (the left side of the operator).
+// Example: equal can be applied onto a column (e.g. myColumn = 'foo') but Boost (^) cannot.
+func canOperateOnColumn(op Operator) bool {
+	return op == Equals || op == Range || op == Greater || op == Less || op == GreaterEq || op == LessEq
 }
 
 func wrapInColumn(in any) (out *Expression) {

--- a/pkg/lucene/expr/operator.go
+++ b/pkg/lucene/expr/operator.go
@@ -25,6 +25,10 @@ const (
 	Literal
 	Wild
 	Regexp
+	Greater
+	Less
+	GreaterEq
+	LessEq
 )
 
 // String renders the operator as a string
@@ -33,33 +37,41 @@ func (o Operator) String() string {
 }
 
 var fromString = map[string]Operator{
-	"AND":      And,
-	"OR":       Or,
-	"EQUALS":   Equals,
-	"LIKE":     Like,
-	"NOT":      Not,
-	"RANGE":    Range,
-	"MUST":     Must,
-	"MUST_NOT": MustNot,
-	"BOOST":    Boost,
-	"FUZZY":    Fuzzy,
-	"LITERAL":  Literal,
-	"WILD":     Wild,
-	"REGEXP":   Regexp,
+	"AND":        And,
+	"OR":         Or,
+	"EQUALS":     Equals,
+	"LIKE":       Like,
+	"NOT":        Not,
+	"RANGE":      Range,
+	"MUST":       Must,
+	"MUST_NOT":   MustNot,
+	"BOOST":      Boost,
+	"FUZZY":      Fuzzy,
+	"LITERAL":    Literal,
+	"WILD":       Wild,
+	"REGEXP":     Regexp,
+	"GREATER":    Greater,
+	"LESS":       Less,
+	"GREATER_EQ": GreaterEq,
+	"LESS_EQ":    LessEq,
 }
 
 var toString = map[Operator]string{
-	And:     "AND",
-	Or:      "OR",
-	Equals:  "EQUALS",
-	Like:    "LIKE",
-	Not:     "NOT",
-	Range:   "RANGE",
-	Must:    "MUST",
-	MustNot: "MUST_NOT",
-	Boost:   "BOOST",
-	Fuzzy:   "FUZZY",
-	Literal: "LITERAL",
-	Wild:    "WILD",
-	Regexp:  "REGEXP",
+	And:       "AND",
+	Or:        "OR",
+	Equals:    "EQUALS",
+	Like:      "LIKE",
+	Not:       "NOT",
+	Range:     "RANGE",
+	Must:      "MUST",
+	MustNot:   "MUST_NOT",
+	Boost:     "BOOST",
+	Fuzzy:     "FUZZY",
+	Literal:   "LITERAL",
+	Wild:      "WILD",
+	Regexp:    "REGEXP",
+	Greater:   "GREATER",
+	Less:      "LESS",
+	GreaterEq: "GREATER_EQ",
+	LessEq:    "LESS_EQ",
 }

--- a/pkg/lucene/expr/renderer.go
+++ b/pkg/lucene/expr/renderer.go
@@ -8,18 +8,22 @@ import (
 type renderer func(e *Expression, verbose bool) string
 
 var renderers = map[Operator]renderer{
-	Equals:  renderEquals,
-	And:     renderBasic,
-	Or:      renderBasic,
-	Not:     renderWrapper,
-	Range:   renderRange,
-	Must:    renderMust,
-	MustNot: renderMustNot,
-	Boost:   renderBoost,
-	Fuzzy:   renderFuzzy,
-	Literal: renderLiteral,
-	Wild:    renderLiteral,
-	Regexp:  renderLiteral,
+	Equals:    renderEquals,
+	And:       renderBasic,
+	Or:        renderBasic,
+	Not:       renderWrapper,
+	Range:     renderRange,
+	Must:      renderMust,
+	MustNot:   renderMustNot,
+	Boost:     renderBoost,
+	Fuzzy:     renderFuzzy,
+	Literal:   renderLiteral,
+	Wild:      renderLiteral,
+	Regexp:    renderLiteral,
+	Greater:   renderBasic,
+	Less:      renderBasic,
+	GreaterEq: renderBasic,
+	LessEq:    renderBasic,
 }
 
 func renderEquals(e *Expression, verbose bool) string {

--- a/pkg/lucene/expr/validator.go
+++ b/pkg/lucene/expr/validator.go
@@ -9,18 +9,22 @@ import (
 type validator = func(*Expression) (err error)
 
 var validators = map[Operator]validator{
-	Equals:  validateEquals,
-	And:     validateAnd,
-	Or:      validateOr,
-	Not:     validateNot,
-	Range:   validateRange,
-	Must:    validateMust,
-	MustNot: validateMustNot,
-	Boost:   validateBoost,
-	Fuzzy:   validateFuzzy,
-	Literal: validateLiteral,
-	Wild:    validateWild,
-	Regexp:  validateRegexp,
+	Equals:    validateEquals,
+	And:       validateAnd,
+	Or:        validateOr,
+	Not:       validateNot,
+	Range:     validateRange,
+	Must:      validateMust,
+	MustNot:   validateMustNot,
+	Boost:     validateBoost,
+	Fuzzy:     validateFuzzy,
+	Literal:   validateLiteral,
+	Wild:      validateWild,
+	Regexp:    validateRegexp,
+	Greater:   validateCompare,
+	Less:      validateCompare,
+	GreaterEq: validateCompare,
+	LessEq:    validateCompare,
 }
 
 func validateEquals(e *Expression) (err error) {
@@ -34,6 +38,22 @@ func validateEquals(e *Expression) (err error) {
 
 	if !isLiteralExpr(e.Left) {
 		return errors.New("EQUALS validation: left value must be a literal expression")
+	}
+
+	return nil
+}
+
+func validateCompare(e *Expression) (err error) {
+	if e == nil {
+		return nil
+	}
+
+	if e.Op != Greater && e.Op != Less && e.Op != GreaterEq && e.Op != LessEq {
+		return errors.New("COMPARE validation error: must have equals operator")
+	}
+
+	if !isLiteralExpr(e.Left) {
+		return errors.New("COMPARE validation: left value must be a literal expression")
 	}
 
 	return nil

--- a/pkg/lucene/reduce/reduce.go
+++ b/pkg/lucene/reduce/reduce.go
@@ -27,9 +27,9 @@ type reducer func(elems []any, nonTerminals []lex.Token) ([]any, []lex.Token, bo
 var reducers = []reducer{
 	and,
 	or,
+	equal,
 	compare,
 	compareEq,
-	equal,
 	not,
 	sub,
 	must,
@@ -113,7 +113,7 @@ func compare(elems []any, nonTerminals []lex.Token) ([]any, []lex.Token, bool) {
 		}
 	}
 
-	return elems, drop(nonTerminals, 1), true
+	return elems, drop(nonTerminals, 2), true
 }
 
 func compareEq(elems []any, nonTerminals []lex.Token) ([]any, []lex.Token, bool) {
@@ -165,7 +165,7 @@ func compareEq(elems []any, nonTerminals []lex.Token) ([]any, []lex.Token, bool)
 		}
 	}
 
-	return elems, drop(nonTerminals, 1), true
+	return elems, drop(nonTerminals, 3), true
 
 }
 

--- a/pkg/lucene/reduce/reduce.go
+++ b/pkg/lucene/reduce/reduce.go
@@ -27,6 +27,8 @@ type reducer func(elems []any, nonTerminals []lex.Token) ([]any, []lex.Token, bo
 var reducers = []reducer{
 	and,
 	or,
+	compare,
+	compareEq,
 	equal,
 	not,
 	sub,
@@ -66,6 +68,105 @@ func equal(elems []any, nonTerminals []lex.Token) ([]any, []lex.Token, bool) {
 	}
 	// we consumed one terminal, the =
 	return elems, drop(nonTerminals, 1), true
+}
+
+func compare(elems []any, nonTerminals []lex.Token) ([]any, []lex.Token, bool) {
+	if len(elems) != 4 {
+		return elems, nonTerminals, false
+	}
+
+	// ensure the middle token is an equals
+	tok, ok := elems[1].(lex.Token)
+	if !ok || (tok.Typ != lex.TColon) {
+		return elems, nonTerminals, false
+	}
+
+	// ensure the middle token is an equals
+	tokCmp, ok := elems[2].(lex.Token)
+	if !ok || (tokCmp.Typ != lex.TGreater && tokCmp.Typ != lex.TLess) {
+		return elems, nonTerminals, false
+	}
+
+	// make sure the left is a literal and right is an expression
+	term, ok := elems[0].(*expr.Expression)
+	if !ok {
+		return elems, nonTerminals, false
+	}
+	value, ok := elems[3].(*expr.Expression)
+	if !ok {
+		return elems, nonTerminals, false
+	}
+
+	if tokCmp.Typ == lex.TGreater {
+		elems = []any{
+			expr.GREATER(
+				term,
+				value,
+			),
+		}
+	} else {
+		elems = []any{
+			expr.LESS(
+				term,
+				value,
+			),
+		}
+	}
+
+	return elems, drop(nonTerminals, 1), true
+}
+
+func compareEq(elems []any, nonTerminals []lex.Token) ([]any, []lex.Token, bool) {
+	if len(elems) != 5 {
+		return elems, nonTerminals, false
+	}
+
+	// ensure the middle token is an equals
+	tok, ok := elems[1].(lex.Token)
+	if !ok || (tok.Typ != lex.TColon) {
+		return elems, nonTerminals, false
+	}
+
+	// ensure the middle token is an equals
+	tokCmp, ok := elems[2].(lex.Token)
+	if !ok || (tokCmp.Typ != lex.TGreater && tokCmp.Typ != lex.TLess) {
+		return elems, nonTerminals, false
+	}
+
+	// ensure the middle token is an equals
+	tokEp, ok := elems[3].(lex.Token)
+	if !ok || (tokEp.Typ != lex.TEqual) {
+		return elems, nonTerminals, false
+	}
+
+	// make sure the left is a literal and right is an expression
+	term, ok := elems[0].(*expr.Expression)
+	if !ok {
+		return elems, nonTerminals, false
+	}
+	value, ok := elems[4].(*expr.Expression)
+	if !ok {
+		return elems, nonTerminals, false
+	}
+
+	if tokCmp.Typ == lex.TGreater {
+		elems = []any{
+			expr.GREATEREQ(
+				term,
+				value,
+			),
+		}
+	} else {
+		elems = []any{
+			expr.LESSEQ(
+				term,
+				value,
+			),
+		}
+	}
+
+	return elems, drop(nonTerminals, 1), true
+
 }
 
 func and(elems []any, nonTerminals []lex.Token) ([]any, []lex.Token, bool) {

--- a/pkg/lucene/reduce/reduce.go
+++ b/pkg/lucene/reduce/reduce.go
@@ -75,13 +75,13 @@ func compare(elems []any, nonTerminals []lex.Token) ([]any, []lex.Token, bool) {
 		return elems, nonTerminals, false
 	}
 
-	// ensure the middle token is an equals
+	// ensure our middle tokens start with a colon
 	tok, ok := elems[1].(lex.Token)
 	if !ok || (tok.Typ != lex.TColon) {
 		return elems, nonTerminals, false
 	}
 
-	// ensure the middle token is an equals
+	// ensure the colon is followed by a > or <
 	tokCmp, ok := elems[2].(lex.Token)
 	if !ok || (tokCmp.Typ != lex.TGreater && tokCmp.Typ != lex.TLess) {
 		return elems, nonTerminals, false
@@ -121,19 +121,19 @@ func compareEq(elems []any, nonTerminals []lex.Token) ([]any, []lex.Token, bool)
 		return elems, nonTerminals, false
 	}
 
-	// ensure the middle token is an equals
+	// ensure our middle tokens start with a colon
 	tok, ok := elems[1].(lex.Token)
 	if !ok || (tok.Typ != lex.TColon) {
 		return elems, nonTerminals, false
 	}
 
-	// ensure the middle token is an equals
+	// ensure the colon is followed by a > or <
 	tokCmp, ok := elems[2].(lex.Token)
 	if !ok || (tokCmp.Typ != lex.TGreater && tokCmp.Typ != lex.TLess) {
 		return elems, nonTerminals, false
 	}
 
-	// ensure the middle token is an equals
+	// ensure the middle tokens are followed by an =
 	tokEp, ok := elems[3].(lex.Token)
 	if !ok || (tokEp.Typ != lex.TEqual) {
 		return elems, nonTerminals, false


### PR DESCRIPTION
elasticsearch lucene syntax
https://www.elastic.co/guide/en/elasticsearch/reference/8.9/query-dsl-query-string-query.html#query-string-syntax

but only support

age:>10
age:>=10
age:<10
age:<=10
not support

age:(>=10 AND <20)
age:(+>=10 +<20)

## fix bug about below case 

```
age:>10 AND age:< 20
age:>=10 AND age:<= 20
```