### PR TITLE
Feature: Wildcards, Fuzzy matching, IN clause, and postgresql bug fixes

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -208,7 +208,11 @@ func TestParseLucene(t *testing.T) {
 		},
 		"basic_escaping": {
 			input: `a:\(1\+1\)\:2`,
-			want:  expr.Eq("a", expr.Lit(`\(1\+1\)\:2`)),
+			want:  expr.Eq("a", expr.Lit(`(1+1):2`)),
+		},
+		"escaped_column_name": {
+			input: `foo\ bar:b`,
+			want:  expr.Eq("foo bar", "b"),
 		},
 		"boost_key_value": {
 			input: "a:b^2 AND foo",

--- a/pkg/driver/postgresql_test.go
+++ b/pkg/driver/postgresql_test.go
@@ -99,14 +99,6 @@ func TestSQLDriver(t *testing.T) {
 			input: expr.MUST(expr.Eq("a", 1)),
 			want:  `a = 1`,
 		},
-		"fuzzy_ignored": {
-			input: expr.FUZZY(expr.Eq("a", 1)),
-			want:  `a = 1`,
-		},
-		"boost_ignored": {
-			input: expr.BOOST(expr.Eq("a", 1)),
-			want:  `a = 1`,
-		},
 		"nested_filter": {
 			input: expr.Expr(
 				expr.Expr(
@@ -128,7 +120,15 @@ func TestSQLDriver(t *testing.T) {
 					expr.Not,
 				),
 			),
-			want: `((a = 'foo') OR (b = '/b*ar/')) AND (NOT(c BETWEEN 'aaa' AND '*'))`,
+			want: `((a = 'foo') OR (b ~ '/b*ar/')) AND (NOT(c BETWEEN 'aaa' AND '*'))`,
+		},
+		"space_in_fieldname": {
+			input: expr.Eq("a b", 1),
+			want:  `"a b" = 1`,
+		},
+		"quoted_column_name": {
+			input: expr.Eq(`"foobar"`, 1),
+			want:  `"foobar" = 1`,
 		},
 	}
 

--- a/pkg/driver/renderfn.go
+++ b/pkg/driver/renderfn.go
@@ -17,9 +17,6 @@ func literal(left, right string) (string, error) {
 }
 
 func equals(left, right string) (string, error) {
-	// at this point the left is considered a column so we should treat it as such
-	// and remove the quotes
-	left = strings.ReplaceAll(left, "\"", "")
 	return fmt.Sprintf("%s = %s", left, right), nil
 }
 
@@ -28,10 +25,21 @@ func noop(left, right string) (string, error) {
 }
 
 func like(left, right string) (string, error) {
-	// at this point the left is considered a column so we should treat it as such
-	// and remove the quotes
-	left = strings.ReplaceAll(left, "'", "")
+	if len(right) >= 4 && right[1] == '/' && right[len(right)-2] == '/' {
+		return fmt.Sprintf("%s ~ %s", left, right), nil
+	}
+
+	right = strings.ReplaceAll(right, "*", "%")
+	right = strings.ReplaceAll(right, "?", "_")
 	return fmt.Sprintf("%s SIMILAR TO %s", left, right), nil
+}
+
+func inFn(left, right string) (string, error) {
+	return fmt.Sprintf("%s IN %s", left, right), nil
+}
+
+func list(left, right string) (string, error) {
+	return fmt.Sprintf("(%s)", left), nil
 }
 
 func greater(left, right string) (string, error) {

--- a/pkg/lucene/expr/expression_test.go
+++ b/pkg/lucene/expr/expression_test.go
@@ -34,10 +34,10 @@ func TestExprJSON(t *testing.T) {
 		"flat_regexp": {
 			input: `{
 				"left": "a",
-				"operator": "EQUALS",
+				"operator": "LIKE",
 				"right": "/b [c]/"
 			  }`,
-			want: Eq(Lit("a"), REGEXP("/b [c]/")),
+			want: LIKE(Lit("a"), REGEXP("/b [c]/")),
 		},
 		"flat_inclusive_range": {
 			input: `{
@@ -140,6 +140,17 @@ func TestExprJSON(t *testing.T) {
 				"distance": 2
 			}`,
 			want: FUZZY("a", 2),
+		},
+		"flat_in_list": {
+			input: `{
+				"left": "a",
+				"operator": "IN",
+				"right": {
+					"left": ["b", "c"],
+					"operator": "LIST"
+				}	
+			}`,
+			want: IN("a", LIST(Lit("b"), Lit("c"))),
 		},
 		"basic_and": {
 			input: `{
@@ -284,7 +295,7 @@ func TestExprJSON(t *testing.T) {
 						"left": {
 							"left": {
 								"left": "b",
-								"operator": "EQUALS",
+								"operator": "LIKE",
 								"right": "/foo?ar.*/"
 							},
 							"operator": "NOT"
@@ -327,7 +338,7 @@ func TestExprJSON(t *testing.T) {
 			want: OR(
 				AND(
 					Rang("a", 1, "*", true),
-					BOOST(NOT(Eq("b", REGEXP("/foo?ar.*/")))),
+					BOOST(NOT(LIKE("b", REGEXP("/foo?ar.*/")))),
 				),
 				OR(
 					MUST(Rang("c", "*", "foo", false)),

--- a/pkg/lucene/expr/operator.go
+++ b/pkg/lucene/expr/operator.go
@@ -8,7 +8,7 @@ type Operator int
 // 1. Add it to the iota here
 // 2. Add it to the string maps below
 // 3. Add a render function for it at least in base, perhaps in all the drivers as well
-// 4. Update the json parsing and tests to suppor the new operator
+// 4. Update the json parsing and tests to support the new operator
 // 5. Add tests in parse_test and expression_test
 const (
 	Undefined Operator = iota
@@ -29,6 +29,8 @@ const (
 	Less
 	GreaterEq
 	LessEq
+	In
+	List
 )
 
 // String renders the operator as a string
@@ -54,6 +56,8 @@ var fromString = map[string]Operator{
 	"LESS":       Less,
 	"GREATER_EQ": GreaterEq,
 	"LESS_EQ":    LessEq,
+	"IN":         In,
+	"LIST":       List,
 }
 
 var toString = map[Operator]string{
@@ -74,4 +78,6 @@ var toString = map[Operator]string{
 	Less:      "LESS",
 	GreaterEq: "GREATER_EQ",
 	LessEq:    "LESS_EQ",
+	In:        "IN",
+	List:      "LIST",
 }

--- a/pkg/lucene/expr/renderer.go
+++ b/pkg/lucene/expr/renderer.go
@@ -24,6 +24,9 @@ var renderers = map[Operator]renderer{
 	Less:      renderBasic,
 	GreaterEq: renderBasic,
 	LessEq:    renderBasic,
+	Like:      renderBasic,
+	In:        renderBasic,
+	List:      renderList,
 }
 
 func renderEquals(e *Expression, verbose bool) string {
@@ -107,6 +110,24 @@ func renderRange(e *Expression, verbose bool) string {
 	}
 
 	return fmt.Sprintf("%s:{%s TO %s}", e.Left, boundary.Min, boundary.Max)
+}
+
+func renderList(e *Expression, verbose bool) string {
+	vals := e.Left.([]*Expression)
+	strs := []string{}
+	for _, v := range vals {
+		if verbose {
+			strs = append(strs, fmt.Sprintf("%#v", v.Left))
+			continue
+		}
+		strs = append(strs, fmt.Sprintf("%s", v.Left))
+	}
+
+	if verbose {
+		return fmt.Sprintf("LIST(%s)", strings.Join(strs, ", "))
+	}
+
+	return fmt.Sprintf("(%s)", strings.Join(strs, ", "))
 }
 
 func renderLiteral(e *Expression, verbose bool) string {

--- a/postgresql_test.go
+++ b/postgresql_test.go
@@ -1,0 +1,250 @@
+package lucene
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/grindlemire/go-lucene/pkg/driver"
+)
+
+func TestPostgresSQLEndToEnd(t *testing.T) {
+	type tc struct {
+		input string
+		want  string
+		err   string
+	}
+
+	tcs := map[string]tc{
+		// "single_literal": {
+		// 	input: "a",
+		// 	want:  "a",
+		// },
+		"basic_equal": {
+			input: "a:b",
+			want:  "a = 'b'",
+		},
+		"basic_equal_with_number": {
+			input: "a:5",
+			want:  "a = 5",
+		},
+		"basic_greater_with_number": {
+			input: "a:>22",
+			want:  "a > 22",
+		},
+		"basic_greater_eq_with_number": {
+			input: "a:>=22",
+			want:  "a >= 22",
+		},
+		"basic_less_with_number": {
+			input: "a:<22",
+			want:  "a < 22",
+		},
+		"basic_less_eq_with_number": {
+			input: "a:<=22",
+			want:  "a <= 22",
+		},
+		"basic_greater_less_with_number": {
+			input: "a:<22 AND b:>33",
+			want:  "(a < 22) AND (b > 33)",
+		},
+		"basic_greater_less_eq_with_number": {
+			input: "a:<=22 AND b:>=33",
+			want:  "(a <= 22) AND (b >= 33)",
+		},
+		"basic_wild_equal_with_*": {
+			input: "a:b*",
+			want:  "a SIMILAR TO 'b%'",
+		},
+		"basic_wild_equal_with_?": {
+			input: "a:b?z",
+			want:  "a SIMILAR TO 'b_z'",
+		},
+		"basic_inclusive_range": {
+			input: "a:[* TO 5]",
+			want:  "a <= 5",
+		},
+		"basic_exclusive_range": {
+			input: "a:{* TO 5}",
+			want:  "a < 5",
+		},
+		"range_over_strings": {
+			input: "a:{foo TO bar}",
+			want:  "a BETWEEN 'foo' AND 'bar'",
+		},
+		"basic_fuzzy": {
+			input: "b AND a~",
+			err:   "unable to render operator [FUZZY]",
+		},
+		"fuzzy_power": {
+			input: "b AND a~10",
+			err:   "unable to render operator [FUZZY]",
+		},
+		"basic_boost": {
+			input: "b AND a^",
+			err:   "unable to render operator [BOOST]",
+		},
+		"boost_power": {
+			input: "b AND a^10",
+			err:   "unable to render operator [BOOST]",
+		},
+		"regexp": {
+			input: "a:/b [c]/",
+			want:  "a ~ '/b [c]/'",
+		},
+		"regexp_with_keywords": {
+			input: `a:/b "[c]/`,
+			want:  `a ~ '/b "[c]/'`,
+		},
+		"basic_default_AND": {
+			input: "a b",
+			want:  "('a') AND ('b')",
+		},
+		"default_to_AND_with_subexpressions": {
+			input: "a:b c:d",
+			want:  "(a = 'b') AND (c = 'd')",
+		},
+		"basic_and": {
+			input: "a AND b",
+			want:  "('a') AND ('b')",
+		},
+		"and_with_nesting": {
+			input: "a:foo AND b:bar",
+			want:  "(a = 'foo') AND (b = 'bar')",
+		},
+		"basic_or": {
+			input: "a OR b",
+			want:  "('a') OR ('b')",
+		},
+		"or_with_nesting": {
+			input: "a:foo OR b:bar",
+			want:  "(a = 'foo') OR (b = 'bar')",
+		},
+		"range_operator_inclusive": {
+			input: "a:[1 TO 5]",
+			want:  "a >= 1 AND a <= 5",
+		},
+		"range_operator_inclusive_unbound": {
+			input: `a:[* TO 200]`,
+			want:  "a <= 200",
+		},
+		"range_operator_exclusive": {
+			input: `a:{"ab" TO "az"}`,
+			want:  "a BETWEEN 'ab' AND 'az'",
+		},
+		"range_operator_exclusive_unbound": {
+			input: `a:{2 TO *}`,
+			want:  "a > 2",
+		},
+		"basic_not": {
+			input: "NOT b",
+			want:  "NOT('b')",
+		},
+		"nested_not": {
+			input: "a:foo OR NOT b:bar",
+			want:  "(a = 'foo') OR (NOT(b = 'bar'))",
+		},
+		"term_grouping": {
+			input: "(a:foo OR b:bar) AND c:baz",
+			want:  "((a = 'foo') OR (b = 'bar')) AND (c = 'baz')",
+		},
+		"value_grouping": {
+			input: "a:(foo OR baz OR bar)",
+			want:  "a IN ('foo', 'baz', 'bar')",
+		},
+		"basic_must": {
+			input: "+a:b",
+			want:  "a = 'b'",
+		},
+		"basic_must_not": {
+			input: "-a:b",
+			want:  "NOT(a = 'b')",
+		},
+		"basic_nested_must_not": {
+			input: "d:e AND (-a:b AND +f:e)",
+			want:  "(d = 'e') AND ((NOT(a = 'b')) AND (f = 'e'))",
+		},
+		"basic_escaping": {
+			input: `a:\(1\+1\)\:2`,
+			want:  `a = '(1+1):2'`,
+		},
+		"escaped_column_name": {
+			input: `foo\ bar:b`,
+			want:  `"foo bar" = 'b'`,
+		},
+		"boost_key_value": {
+			input: "a:b^2 AND foo",
+			err:   "unable to render operator [BOOST]",
+		},
+		"nested_sub_expressions": {
+			input: "((title:foo OR title:bar) AND (body:foo OR body:bar)) OR k:v",
+			want:  "(((title = 'foo') OR (title = 'bar')) AND ((body = 'foo') OR (body = 'bar'))) OR (k = 'v')",
+		},
+		"fuzzy_key_value": {
+			input: "a:b~2 AND foo",
+			err:   "unable to render operator [FUZZY]",
+		},
+		"precedence_works": {
+			input: "a:b AND c:d OR e:f OR h:i AND j:k",
+			want:  "(((a = 'b') AND (c = 'd')) OR (e = 'f')) OR ((h = 'i') AND (j = 'k'))",
+		},
+		"test_precedence_weaving": {
+			input: "a OR b AND c OR d",
+			want:  "(('a') OR (('b') AND ('c'))) OR ('d')",
+		},
+		"test_precedence_weaving_with_not": {
+			input: "NOT a OR b AND NOT c OR d",
+			want:  "((NOT('a')) OR (('b') AND (NOT('c')))) OR ('d')",
+		},
+		"test_equals_in_precedence": {
+			input: "a:az OR b:bz AND NOT c:z OR d",
+			want:  "((a = 'az') OR ((b = 'bz') AND (NOT(c = 'z')))) OR ('d')",
+		},
+		"test_parens_in_precedence": {
+			input: "a AND (c OR d)",
+			want:  "('a') AND (('c') OR ('d'))",
+		},
+		"test_range_precedance_simple": {
+			input: "c:[* to -1] OR d",
+			want:  "(c <= -1) OR ('d')",
+		},
+		"test_range_precedance": {
+			input: "a OR b AND c:[* to -1] OR d",
+			want:  "(('a') OR (('b') AND (c <= -1))) OR ('d')",
+		},
+		"test_full_precedance": {
+			input: "a OR b AND c:[* to -1] OR d AND NOT +e:f",
+			want:  "(('a') OR (('b') AND (c <= -1))) OR (('d') AND (NOT(e = 'f')))",
+		},
+		"test_elastic_greater_than_precedance": {
+			input: "a:>10 AND -b:<=-20",
+			want:  "(a > 10) AND (NOT(b <= -20))",
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+
+			expr, err := Parse(tc.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := driver.NewPostgresDriver().Render(expr)
+			if err != nil {
+				// if we got an expect error then we are fine
+				if tc.err != "" && strings.Contains(err.Error(), tc.err) {
+					return
+				}
+				t.Fatalf("unexpected error rendering expression: %v", err)
+			}
+
+			if tc.err != "" {
+				t.Fatalf("\nexpected error [%s]\ngot: %s", tc.err, got)
+			}
+
+			if got != tc.want {
+				t.Fatalf("\nwant %s\ngot  %s\nparsed expression: %#v\n", tc.want, got, expr)
+			}
+		})
+	}
+}

--- a/release-process.md
+++ b/release-process.md
@@ -1,5 +1,7 @@
 # Release Process
 
+### Note this might be out of date, I have to figure out what is going on here
+
 ## Rules for release branches:
 
 -   If you are releasing a new major version you need to branch off of master into a branch `release-branch.v#` (example `release-branch.v2` for a 2.x release)


### PR DESCRIPTION
This covers quite a few gaps I found when implementing end to end postgres tests. Specifically:
- Support for generating `IN` clauses. Example: `foo:(bar OR baz OR bbq)` will now generate `foo IN ('bar', 'baz', 'bbq')`
- Support for the `SIMILAR TO` operator. Example: `foo:b?a*` will now generate `foo SIMILAR TO 'b_a%'`
- Support for regular expression mattching. Example: `foo:/b(a|b)*/` will now generate `foo ~ '/b(a|b)*/'`
- Support for elastic greater and less than operators. Example: `foo:<20 AND bar:>=10` will now generate `foo < 20 AND bar >=10`. Thanks for the contribution @bigpigeon! 
- A bunch of bug fixes.