### PR TITLE
bugfix: support escaped characters in regular expressions

### DIFF
--- a/internal/lex/lex.go
+++ b/internal/lex/lex.go
@@ -278,8 +278,10 @@ func lexRegexp(l *Lexer) tokenStateFn {
 
 	for {
 		switch r := l.next(); {
-		case isAlphaNumeric(r) || isWildcard(r) || isEscape(r):
+		case isAlphaNumeric(r) || isWildcard(r):
 			// do nothing
+		case isEscape(r):
+			l.next() // just ignore the next character
 		case r == ' ' || r == '\t' || r == '\r' || r == '\n':
 			// do nothing
 		case r == open:

--- a/internal/lex/lext_test.go
+++ b/internal/lex/lext_test.go
@@ -147,6 +147,12 @@ func TestLex(t *testing.T) {
 				tok(TRegexp, "/a[b]*/"),
 			},
 		},
+		"regexp_tokenized_with_escaped_chars": {
+			in: `/.*example.com\/article\/.*/`,
+			expected: []Token{
+				tok(TRegexp, `/.*example.com\/article\/.*/`),
+			},
+		},
 		"symbols_tokenized": {
 			in: `()[]{}:+-=><`,
 			expected: []Token{

--- a/parse_test.go
+++ b/parse_test.go
@@ -98,6 +98,10 @@ func TestParseLucene(t *testing.T) {
 			input: `a:/b "[c]/`,
 			want:  expr.Eq("a", expr.REGEXP(`/b "[c]/`)),
 		},
+		"regexp_with_escaped_chars": {
+			input: `url:/example.com\/foo\/bar\/.*/`,
+			want:  expr.Eq("url", expr.REGEXP(`/example.com\/foo\/bar\/.*/`)),
+		},
 		"basic_default_AND": {
 			input: "a b",
 			want:  expr.AND("a", "b"),

--- a/postgresql_test.go
+++ b/postgresql_test.go
@@ -95,6 +95,10 @@ func TestPostgresSQLEndToEnd(t *testing.T) {
 			input: `a:/b "[c]/`,
 			want:  `a ~ '/b "[c]/'`,
 		},
+		"regexp_with_escaped_chars": {
+			input: `url:/example.com\/foo\/bar\/.*/`,
+			want:  `url ~ '/example.com\/foo\/bar\/.*/'`,
+		},
 		"basic_default_AND": {
 			input: "a b",
 			want:  "('a') AND ('b')",
@@ -223,7 +227,6 @@ func TestPostgresSQLEndToEnd(t *testing.T) {
 
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
-
 			expr, err := Parse(tc.input)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Fixes #9 

Now regular expressions will properly parse escaped characters.