### PR TITLE
Remove log in validator

### DIFF
--- a/pkg/lucene/expr/validator.go
+++ b/pkg/lucene/expr/validator.go
@@ -350,7 +350,6 @@ func validateList(e *Expression) (err error) {
 }
 
 func isListOfLiteralExprs(in any) bool {
-	fmt.Println(reflect.TypeOf(in))
 	e, isList := in.([]*Expression)
 	if !isList {
 		return false


### PR DESCRIPTION
I'm removing a log in the validator which is not really needed and there's no way to deactivate it. It seems to be left there by mistake