### PR TITLE
optimize IsTerminal

### DIFF
--- a/internal/lex/lex.go
+++ b/internal/lex/lex.go
@@ -117,35 +117,23 @@ func (tt TokType) String() string {
 	}[tt]
 }
 
+
+// terminalTokens contains a map of terminal tokens.
+// Uses empty struct value to conserve memory.
+var terminalTokens = map[TokType]struct{}{
+	TErr:     struct{}{},
+	TLiteral: struct{}{},
+	TQuoted:  struct{}{},
+	TRegexp:  struct{}{},
+	TEOF:     struct{}{},
+}
+
 // IsTerminal checks wether a specific token is a terminal token meaning
 // it can't be matched in the grammar.
 func IsTerminal(tok Token) bool {
-	return map[TokType]bool{
-		TErr:     true,
-		TLiteral: true,
-		TQuoted:  true,
-		TRegexp:  true,
-		TEqual:   false,
-		TLParen:  false,
-		TRParen:  false,
-		TAnd:     false,
-		TOr:      false,
-		TNot:     false,
-		TLSquare: false,
-		TRSquare: false,
-		TLCurly:  false,
-		TRCurly:  false,
-		TTO:      false,
-		TColon:   false,
-		TPlus:    false,
-		TMinus:   false,
-		TGreater: false,
-		TLess:    false,
-		TTilde:   false,
-		TCarrot:  false,
-		TEOF:     true,
-		TStart:   false,
-	}[tok.Typ]
+	_, terminal := terminalTokens[tok.Typ]
+
+	return terminal
 }
 
 // HasLessPrecedence checks if a current token has lower precedence than the next.


### PR DESCRIPTION
  - use global map instead of allocating per func call
  - use empty struct as map value which takes 0 bytes instead of bool

This func is called from the lexer for loop so should give a good speed increase and reduce memory allocaitons.