### PR TITLE
Add an option for a default field when parsing

### DIFF
--- a/fuzz/fuzz_test.go
+++ b/fuzz/fuzz_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grindlemire/go-lucene"
 	"github.com/grindlemire/go-lucene/pkg/driver"
+	"github.com/grindlemire/go-lucene/pkg/lucene/expr"
 	pg_query "github.com/pganalyze/pg_query_go/v4"
 )
 
@@ -34,28 +35,41 @@ func FuzzPostgresDriver(f *testing.F) {
 			return
 		}
 
-		f, err := driver.NewPostgresDriver().Render(e)
+		validateRender(t, e)
+
+		// Test the default field option.
+		e, err = lucene.Parse(in, lucene.WithDefaultField("default"))
 		if err != nil {
-			// Ignore errors that are expected.
-			if strings.Contains(err.Error(), "unable to render operator") ||
-				strings.Contains(err.Error(), "literal contains invalid utf8") ||
-				strings.Contains(err.Error(), "literal contains null byte") ||
-				strings.Contains(err.Error(), "column name contains a double quote") ||
-				strings.Contains(err.Error(), "column name is empty") ||
-				strings.Contains(err.Error(), "the BETWEEN operator needs a two item list in the right hand side") {
-				return
-			}
-
-			t.Fatal(err)
+			// Ignore invalid expressions.
+			return
 		}
 
-		j, err := pg_query.ParseToJSON("SELECT * FROM test WHERE a = b AND (" + f + ")")
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if strings.Contains(j, "CommentStmt") {
-			t.Fatal("CommentStmt found")
-		}
+		validateRender(t, e)
 	})
+}
+
+func validateRender(t *testing.T, e *expr.Expression) {
+	f, err := driver.NewPostgresDriver().Render(e)
+	if err != nil {
+		// Ignore errors that are expected.
+		if strings.Contains(err.Error(), "unable to render operator") ||
+			strings.Contains(err.Error(), "literal contains invalid utf8") ||
+			strings.Contains(err.Error(), "literal contains null byte") ||
+			strings.Contains(err.Error(), "column name contains a double quote") ||
+			strings.Contains(err.Error(), "column name is empty") ||
+			strings.Contains(err.Error(), "the BETWEEN operator needs a two item list in the right hand side") {
+			return
+		}
+
+		t.Fatal(err)
+	}
+
+	j, err := pg_query.ParseToJSON("SELECT * FROM test WHERE a = b AND (" + f + ")")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(j, "CommentStmt") {
+		t.Fatal("CommentStmt found")
+	}
 }

--- a/postgresql_test.go
+++ b/postgresql_test.go
@@ -7,9 +7,10 @@ import (
 
 func TestPostgresSQLEndToEnd(t *testing.T) {
 	type tc struct {
-		input string
-		want  string
-		err   string
+		input        string
+		want         string
+		defaultField string
+		err          string
 	}
 
 	tcs := map[string]tc{
@@ -229,11 +230,26 @@ func TestPostgresSQLEndToEnd(t *testing.T) {
 			input: "1a:b",
 			want:  `"1a" = 'b'`,
 		},
+		"default_field_and": {
+			input:        `title:"The Right Way" AND go`,
+			want:         `("title" = 'The Right Way') AND ("default" = 'go')`,
+			defaultField: "default",
+		},
+		"default_field_or": {
+			input:        `title:"The Right Way" OR go`,
+			want:         `("title" = 'The Right Way') OR ("default" = 'go')`,
+			defaultField: "default",
+		},
+		"default_field_not": {
+			input:        `title:"The Right Way" AND NOT(go)`,
+			want:         `("title" = 'The Right Way') AND (NOT("default" = 'go'))`,
+			defaultField: "default",
+		},
 	}
 
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
-			got, err := ToPostgres(tc.input)
+			got, err := ToPostgres(tc.input, WithDefaultField(tc.defaultField))
 			if err != nil {
 				// if we got an expect error then we are fine
 				if tc.err != "" && strings.Contains(err.Error(), tc.err) {

--- a/render.go
+++ b/render.go
@@ -7,8 +7,8 @@ var (
 )
 
 // ToPostgres is a wrapper that will render the lucene expression string as a postgres sql filter string.
-func ToPostgres(in string) (string, error) {
-	e, err := Parse(in)
+func ToPostgres(in string, opts ...opt) (string, error) {
+	e, err := Parse(in, opts...)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This allows expressions with bare literals to be turned into equals expressions for a default field. 

Example:
```go
str, _ := lucene.Parse("a:foo AND bar", lucene.WithDefaultField("baz"))
fmt.Println(str) // prints ("a" = 'foo') AND ("baz" = 'bar')
```

This logic also is applied to OR and NOT expressions. See the tests for more examples.

Fixes #20 