### PR TITLE
Parameterized Postgres Queries

### DIFF
--- a/pkg/driver/base.go
+++ b/pkg/driver/base.go
@@ -36,6 +36,8 @@ type Base struct {
 	RenderFNs map[expr.Operator]RenderFN
 }
 
+// RenderParam will render the expression into a parameterized query. The returned string will contain placeholders
+// and the params will contain the values that should be passed to the query.
 func (b Base) RenderParam(e *expr.Expression) (s string, params []any, err error) {
 	if e == nil {
 		return "", params, nil

--- a/pkg/driver/base.go
+++ b/pkg/driver/base.go
@@ -36,6 +36,72 @@ type Base struct {
 	RenderFNs map[expr.Operator]RenderFN
 }
 
+func (b Base) RenderParam(e *expr.Expression) (s string, params []any, err error) {
+	if e == nil {
+		return "", params, nil
+	}
+
+	left, lparams, err := b.serializeParams(e.Left)
+	if err != nil {
+		return s, params, err
+	}
+
+	right, rparams, err := b.serializeParams(e.Right)
+	if err != nil {
+		return s, params, err
+	}
+
+	// if we are in a regular expression we need to convert the * to % and ? to _
+	if e.Op == expr.Like {
+		rval := rparams[0].(string)
+		// keep the regexp intact if it is a // regexp
+		if len(rval) < 4 || rval[0] != '/' || rval[len(rval)-1] != '/' {
+			rval = strings.ReplaceAll(rval, "*", "%")
+			rval = strings.ReplaceAll(rval, "?", "_")
+			rparams[0] = rval
+		}
+	}
+
+	params = append(lparams, rparams...)
+
+	if e.Op != expr.Range &&
+		e.Op != expr.Not &&
+		e.Op != expr.List &&
+		e.Op != expr.In &&
+		e.Op != expr.Literal &&
+		e.Op != expr.Must &&
+		e.Op != expr.MustNot {
+		if !b.isSimple(e.Left) {
+			left = "(" + left + ")"
+		}
+		if !b.isSimple(e.Right) {
+			right = "(" + right + ")"
+		}
+	}
+
+	// if we have a like operator then we need to use the likeParam function instead of the default
+	// since we are replacing all the * with % and ? with _
+	if e.Op == expr.Like {
+		str, err := likeParam(left, right, rparams)
+		return str, params, err
+	}
+
+	// if we have a range operator then we need to use the rangParam function instead of the default
+	// since we need to be able to infer the param types that are injected
+	if e.Op == expr.Range {
+		str, err := rangParam(left, right, rparams)
+		return str, params, err
+	}
+
+	fn, ok := b.RenderFNs[e.Op]
+	if !ok {
+		return s, params, fmt.Errorf("unable to render operator [%s]", e.Op)
+	}
+
+	str, err := fn(left, right)
+	return str, params, err
+}
+
 // Render will render the expression based on the renderFNs provided by the driver.
 func (b Base) Render(e *expr.Expression) (s string, err error) {
 	if e == nil {
@@ -52,7 +118,13 @@ func (b Base) Render(e *expr.Expression) (s string, err error) {
 		return s, err
 	}
 
-	if e.Op != expr.Range && e.Op != expr.Not && e.Op != expr.List && e.Op != expr.In && e.Op != expr.Literal && e.Op != expr.Must && e.Op != expr.MustNot {
+	if e.Op != expr.Range &&
+		e.Op != expr.Not &&
+		e.Op != expr.List &&
+		e.Op != expr.In &&
+		e.Op != expr.Literal &&
+		e.Op != expr.Must &&
+		e.Op != expr.MustNot {
 		if !b.isSimple(e.Left) {
 			left = "(" + left + ")"
 		}
@@ -133,5 +205,64 @@ func (b Base) serialize(in any) (s string, err error) {
 		return fmt.Sprintf("'%s'", strings.ReplaceAll(v, "'", "''")), nil
 	default:
 		return fmt.Sprintf("%v", v), nil
+	}
+}
+
+func (b Base) serializeParams(in any) (s string, params []any, err error) {
+	if in == nil {
+		return "", params, nil
+	}
+
+	switch v := in.(type) {
+	case *expr.Expression:
+		return b.RenderParam(v)
+	case []*expr.Expression:
+		strs := []string{}
+		for _, e := range v {
+			s, eparams, err := b.RenderParam(e)
+			if err != nil {
+				return s, params, err
+			}
+			strs = append(strs, s)
+			params = append(params, eparams...)
+		}
+		return strings.Join(strs, ", "), params, nil
+	case *expr.RangeBoundary:
+		min, minParams, err := b.serializeParams(v.Min)
+		if err != nil {
+			return "", params, err
+		}
+		max, maxParams, err := b.serializeParams(v.Max)
+		if err != nil {
+			return "", params, err
+		}
+		params = append(minParams, maxParams...)
+
+		if v.Inclusive {
+			return fmt.Sprintf("[%s, %s]", min, max), params, nil
+		}
+		return fmt.Sprintf("(%s, %s)", min, max), params, nil
+
+	case expr.Column:
+		if len(v) == 0 {
+			return "", params, fmt.Errorf("column name is empty")
+		}
+		if strings.ContainsRune(string(v), '"') {
+			return "", params, fmt.Errorf("column name contains a double quote: %q", v)
+		}
+		// Always escape column names with double quotes,
+		// otherwise we need to know the reserved words
+		// which might change in the future.
+		return fmt.Sprintf(`"%s"`, string(v)), params, nil
+	case string:
+		// if we have a '*' then we don't want to insert a param
+		if v == "*" {
+			return "'*'", params, nil
+		}
+
+		// escape single quotes with double single quotes
+		return "?", []any{v}, nil
+	default:
+		return "?", []any{v}, nil
 	}
 }

--- a/pkg/driver/renderfn.go
+++ b/pkg/driver/renderfn.go
@@ -42,6 +42,17 @@ func like(left, right string) (string, error) {
 	return fmt.Sprintf("%s SIMILAR TO %s", left, right), nil
 }
 
+func likeParam(left, right string, params []any) (string, error) {
+	if len(params) == 1 {
+		pright := params[0].(string)
+		if len(pright) >= 4 && pright[0] == '/' && pright[len(pright)-1] == '/' {
+			return fmt.Sprintf("%s ~ %s", left, right), nil
+		}
+	}
+
+	return fmt.Sprintf("%s SIMILAR TO %s", left, right), nil
+}
+
 func inFn(left, right string) (string, error) {
 	return fmt.Sprintf("%s IN %s", left, right), nil
 }
@@ -162,6 +173,146 @@ func rang(left, right string) (string, error) {
 		nil
 }
 
+func rangParam(left, right string, params []any) (string, error) {
+	inclusive := true
+	if right[0] == '(' && right[len(right)-1] == ')' {
+		inclusive = false
+	}
+
+	stripped := right[1 : len(right)-1]
+	rangeSlice := strings.Split(stripped, ",")
+
+	if len(rangeSlice) != 2 {
+		return "", fmt.Errorf("the BETWEEN operator needs a two item list in the right hand side, have %s", right)
+	}
+
+	rawMin := strings.Trim(rangeSlice[0], " ")
+	rawMax := strings.Trim(rangeSlice[1], " ")
+
+	// if we have a parameterized input then we need to check the type
+	if rawMin == "?" || rawMax == "?" {
+		switch params[0].(type) {
+		case int, float64, float32:
+			if rawMin == "'*'" {
+				if inclusive {
+					return fmt.Sprintf("%s <= %s", left, rawMax), nil
+				}
+				return fmt.Sprintf("%s < %s", left, rawMax), nil
+			}
+
+			if rawMax == "'*'" {
+				if inclusive {
+					return fmt.Sprintf("%s >= %s", left, rawMin), nil
+				}
+				return fmt.Sprintf("%s > %s", left, rawMin), nil
+			}
+
+			if inclusive {
+				return fmt.Sprintf("%s >= %s AND %s <= %s",
+						left,
+						rawMin,
+						left,
+						rawMax,
+					),
+					nil
+			}
+
+			return fmt.Sprintf("%s > %s AND %s < %s",
+					left,
+					rawMin,
+					left,
+					rawMax,
+				),
+				nil
+		default:
+			return fmt.Sprintf(`%s BETWEEN %s AND %s`,
+					left,
+					strings.Trim(rangeSlice[0], " "),
+					strings.Trim(rangeSlice[1], " "),
+				),
+				nil
+		}
+
+	}
+
+	iMin, iMax, err := toInts(rawMin, rawMax)
+	if err == nil {
+		if rawMin == "'*'" {
+			if inclusive {
+				return fmt.Sprintf("%s <= %d", left, iMax), nil
+			}
+			return fmt.Sprintf("%s < %d", left, iMax), nil
+		}
+
+		if rawMax == "'*'" {
+			if inclusive {
+				return fmt.Sprintf("%s >= %d", left, iMin), nil
+			}
+			return fmt.Sprintf("%s > %d", left, iMin), nil
+		}
+
+		if inclusive {
+			return fmt.Sprintf("%s >= %d AND %s <= %d",
+					left,
+					iMin,
+					left,
+					iMax,
+				),
+				nil
+		}
+
+		return fmt.Sprintf("%s > %d AND %s < %d",
+				left,
+				iMin,
+				left,
+				iMax,
+			),
+			nil
+	}
+
+	fMin, fMax, err := toFloats(rawMin, rawMax)
+	if err == nil {
+		if rawMin == "'*'" {
+			if inclusive {
+				return fmt.Sprintf("%s <= %.2f", left, fMax), nil
+			}
+			return fmt.Sprintf("%s < %.2f", left, fMax), nil
+		}
+
+		if rawMax == "'*'" {
+			if inclusive {
+				return fmt.Sprintf("%s >= %.2f", left, fMin), nil
+			}
+			return fmt.Sprintf("%s > %.2f", left, fMin), nil
+		}
+
+		if inclusive {
+			return fmt.Sprintf("%s >= %.2f AND %s <= %.2f",
+					left,
+					fMin,
+					left,
+					fMax,
+				),
+				nil
+		}
+
+		return fmt.Sprintf("%s > %.2f AND %s < %.2f",
+				left,
+				fMin,
+				left,
+				fMax,
+			),
+			nil
+	}
+
+	return fmt.Sprintf(`%s BETWEEN %s AND %s`,
+			left,
+			strings.Trim(rangeSlice[0], " "),
+			strings.Trim(rangeSlice[1], " "),
+		),
+		nil
+}
+
 func basicCompound(op expr.Operator) RenderFN {
 	return func(left, right string) (string, error) {
 		return fmt.Sprintf("%s %s %s", left, op, right), nil
@@ -190,12 +341,12 @@ func toInts(rawMin, rawMax string) (iMin, iMax int, err error) {
 
 func toFloats(rawMin, rawMax string) (fMin, fMax float64, err error) {
 	fMin, err = strconv.ParseFloat(rawMin, 64)
-	if rawMin != "'*'" && err != nil {
+	if rawMin != "*" && err != nil {
 		return 0, 0, err
 	}
 
 	fMax, err = strconv.ParseFloat(rawMax, 64)
-	if rawMax != "'*'" && err != nil {
+	if rawMax != "*" && err != nil {
 		return 0, 0, err
 	}
 

--- a/postgresql_test.go
+++ b/postgresql_test.go
@@ -568,7 +568,7 @@ func TestPostgresParameterizedSQLEndToEnd(t *testing.T) {
 
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
-			gotStr, gotParams, err := ToPostgresParams(tc.input, WithDefaultField(tc.defaultField))
+			gotStr, gotParams, err := ToParameterizedPostgres(tc.input, WithDefaultField(tc.defaultField))
 			if err != nil {
 				// if we got an expect error then we are fine
 				if tc.err != "" && strings.Contains(err.Error(), tc.err) {

--- a/render.go
+++ b/render.go
@@ -15,3 +15,14 @@ func ToPostgres(in string, opts ...opt) (string, error) {
 
 	return postgres.Render(e)
 }
+
+// ToParameterizedPostgres is a wrapper that will render the lucene expression string as a postgres sql filter string with parameters.
+// The returned string will contain placeholders for the parameters that can be passed directly to a Query statement.
+func ToParameterizedPostgres(in string, opts ...opt) (s string, params []any, err error) {
+	e, err := Parse(in, opts...)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return postgres.RenderParam(e)
+}


### PR DESCRIPTION
This adds new functionality for generating parameterized postgres queries in addition to rendered postgres queries. Any user provided input is rendered as a `?` and a list of parameters are returned. The user can pass both of these to a `Query` call in a postgres driver.

Example:
```go
str, params, err := lucene.ToParamaterizedPostgres(`a:b AND NOT c:"d"`)
// str is (a = ?) AND NOT(c = ?)
// params is ["b", "d"]
...
db.Query(str, params...)

```

Fixes #21 