### PR TITLE
bugfix: Handle single literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ With this package you can quickly integrate lucene style searching inside your a
 Out of the box go-lucene support postgres compliant sql generation but it can be extended to support different flavors of sql (or no sql) as well.
 
 # Usage
-Use `lucene.ToPostgres` to generate a single string with all your filters in it
+Use `lucene.ToPostgres` to generate a single string with all your filters in it.
 
-Use `lucene.ToParmeterizedPostgres` to generate a parameterized string with args that you can pass to your DB query
+Use `lucene.ToParmeterizedPostgres` to generate a parameterized string with args that you can pass to your DB query.
+
+Use the `lucene.WithDefaultField` option to associate bare literals with a field.
 
 
 ## Pure String
@@ -68,6 +70,33 @@ LIMIT 10;
 sqlQuery := fmt.Sprintf(SQLTemplate, filter)
 
 db.Query(sqlQuery, params)
+```
+
+## Default Fields
+```go
+myQuery := "red OR green"
+filter, err := lucene.ToPostgres(
+	myQuery, lucene.WithDefaultField("appleColor"))
+if err != nil {
+    // handle error
+}
+
+SQLTemplate := `
+SELECT *
+FROM apples
+WHERE %s
+LIMIT 10;
+`
+sqlQuery := fmt.Sprintf(SQLTemplate, filter)
+
+// sqlQuery is:
+`
+SELECT *
+FROM apples
+WHERE
+    ("appleColor" = 'red') OR ("appleColor" = 'green')
+LIMIT 10;
+`
 ```
 
 ## Extending with a custom driver

--- a/parse.go
+++ b/parse.go
@@ -70,6 +70,12 @@ func (p *parser) parse() (e *expr.Expression, err error) {
 					reflect.TypeOf(final),
 				)
 			}
+
+			// edge case for a single literal in the expression and a default field specified
+			if final.Op == expr.Literal && p.defaultField != "" {
+				final = expr.Expr(p.defaultField, expr.Equals, final.Left)
+			}
+
 			return final, nil
 		}
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -539,6 +539,54 @@ func TestParseLucene(t *testing.T) {
 	}
 }
 
+func TestParseLuceneWithDefaultField(t *testing.T) {
+	type tc struct {
+		input        string
+		defaultField string
+		want         *expr.Expression
+	}
+
+	tcs := map[string]tc{
+		"single_literal": {
+			input:        "a",
+			defaultField: "foo",
+			want:         expr.Eq("foo", "a"),
+		},
+		"quoted_literal": {
+			input:        `"a"`,
+			defaultField: "foo",
+			want:         expr.Eq("foo", "a"),
+		},
+		"number_literal": {
+			input:        `7`,
+			defaultField: "foo",
+			want:         expr.Eq("foo", 7),
+		},
+		"multiple_literals": {
+			input:        "a b",
+			defaultField: "foo",
+			want:         expr.AND(expr.Eq("foo", "a"), expr.Eq("foo", "b")),
+		},
+		"basic_and": {
+			input:        "a AND b",
+			defaultField: "foo",
+			want:         expr.AND(expr.Eq("foo", "a"), expr.Eq("foo", "b")),
+		},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			got, err := Parse(tc.input, WithDefaultField(tc.defaultField))
+			if err != nil {
+				t.Fatalf("wanted no error, got: %v", err)
+			}
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf(errTemplate, "parsed expression doesn't match", tc.want, got)
+			}
+		})
+	}
+}
+
 func TestParseFailure(t *testing.T) {
 	type tc struct {
 		input string

--- a/pkg/lucene/reduce/reduce.go
+++ b/pkg/lucene/reduce/reduce.go
@@ -510,7 +510,7 @@ func toPositiveFloat(in string) (f float64, err error) {
 	return f, fmt.Errorf("[%v] is not a positive float", in)
 }
 
-// wrapLiteral will wrap a literal expression in an equals expression for a defaultdefaultFieldd.
+// wrapLiteral will wrap a literal expression in an equals expression for a defaultField.
 // we need this because we want to support lucene expressions like a:b AND "c" which needs a default
 // field to compare "c" against to be valid.
 func wrapLiteral(lit *expr.Expression, field string) *expr.Expression {

--- a/postgresql_test.go
+++ b/postgresql_test.go
@@ -564,6 +564,18 @@ func TestPostgresParameterizedSQLEndToEnd(t *testing.T) {
 			wantParams:   []any{"The Right Way", "go"},
 			defaultField: "default",
 		},
+		"default_bare_field": {
+			input:        `this is an example`,
+			wantStr:      `((("default" = ?) AND ("default" = ?)) AND ("default" = ?)) AND ("default" = ?)`,
+			wantParams:   []any{"this", "is", "an", "example"},
+			defaultField: "default",
+		},
+		"default_single_literal": {
+			input:        `a`,
+			wantStr:      `"default" = ?`,
+			wantParams:   []any{"a"},
+			defaultField: "default",
+		},
 	}
 
 	for name, tc := range tcs {


### PR DESCRIPTION
Fixes #24

There was a bug in the default field code where a single literal was not being properly matched to a provided default field.

Example:
```go
ToPostgresSQL("a", WithDefaultField("foo"))
// output was just 'a'
```

Should have been
```go
ToPostgresSQL("a", WithDefaultField("foo"))
// output should be "foo" = 'a'
```

This is now fixed and the readme updated. I also added some tests to enforce the edge case.