### PR TITLE
#48 fixing parser failing on comma

### DIFF
--- a/internal/lex/lex.go
+++ b/internal/lex/lex.go
@@ -206,7 +206,7 @@ func lexSpace(l *Lexer) tokenStateFn {
 		switch l.next() {
 		case eof:
 			return nil
-		case ' ', '\t', '\r', '\n':
+		case ' ', '\t', '\r', '\n', ',':
 			continue
 		default:
 			// transition to being in a value

--- a/parse_test.go
+++ b/parse_test.go
@@ -643,6 +643,71 @@ func TestParseLucene(t *testing.T) {
 			input: "50%done",
 			want:  expr.Lit("50%done"),
 		},
+		// comma tests — unquoted commas are word boundaries; quoted commas are preserved literally
+		"comma_as_word_boundary": {
+			input: "foo, bar",
+			want:  expr.AND(expr.Lit("foo"), expr.Lit("bar")),
+		},
+		"comma_only_separator": {
+			input: "foo,bar",
+			want:  expr.AND(expr.Lit("foo"), expr.Lit("bar")),
+		},
+		"comma_multiple_terms": {
+			input: "foo, bar, baz",
+			want:  expr.AND(expr.AND(expr.Lit("foo"), expr.Lit("bar")), expr.Lit("baz")),
+		},
+		"quoted_phrase_with_comma_preserved": {
+			input: `"foo, bar"`,
+			want:  expr.Lit("foo, bar"),
+		},
+		"quoted_phrase_with_comma_in_field_value": {
+			input: `name:"Smith, John"`,
+			want:  expr.Eq("name", "Smith, John"),
+		},
+		"quoted_phrase_with_comma_in_compound": {
+			input: `"foo, bar" AND baz`,
+			want:  expr.AND(expr.Lit("foo, bar"), expr.Lit("baz")),
+		},
+		"escaped_brackets_with_wildcard_and_comma_separated_terms": {
+			input: `\[*\] Actual go routines \[*\], allocated objects in bytes \[*\], allocated objects \[*\]`,
+			want: expr.AND(
+				expr.AND(
+					expr.AND(
+						expr.AND(
+							expr.AND(
+								expr.AND(
+									expr.AND(
+										expr.AND(
+											expr.AND(
+												expr.AND(
+													expr.AND(
+														expr.AND(
+															expr.WILD(`\[*\]`),
+															expr.Lit("Actual"),
+														),
+														expr.Lit("go"),
+													),
+													expr.Lit("routines"),
+												),
+												expr.WILD(`\[*\]`),
+											),
+											expr.Lit("allocated"),
+										),
+										expr.Lit("objects"),
+									),
+									expr.Lit("in"),
+								),
+								expr.Lit("bytes"),
+							),
+							expr.WILD(`\[*\]`),
+						),
+						expr.Lit("allocated"),
+					),
+					expr.Lit("objects"),
+				),
+				expr.WILD(`\[*\]`),
+			),
+		},
 	}
 
 	for name, tc := range tcs {


### PR DESCRIPTION
## Fix: unquoted commas crash the parser (#48)

Commas in bare queries (e.g. `foo, bar, baz`) caused a fatal parse error because the lexer had no handler for `,` outside of quoted strings.

**Fix:** treat unquoted commas as whitespace (word boundaries) in the lexer, consistent with standard Lucene behaviour. Commas inside quoted phrases (`"Smith, John"`) are unaffected.

**Changed:** `internal/lex/lex.go` — one line, added `,` to the skip set in `lexSpace`.

**Tests added** in `parse_test.go` covering unquoted comma as separator (`foo, bar` → `foo AND bar`) and quoted comma preserved verbatim (`"foo, bar"` → `LITERAL("foo, bar")`), as well as a more complex `\[*\] Actual go routines \[*\], allocated objects in bytes \[*\], allocated objects \[*\]`