### PR TITLE
Fix parser breaking on commas

### DIFF
--- a/internal/lex/lex.go
+++ b/internal/lex/lex.go
@@ -206,7 +206,7 @@ func lexSpace(l *Lexer) tokenStateFn {
 		switch l.next() {
 		case eof:
 			return nil
-		case ' ', '\t', '\r', '\n':
+		case ' ', '\t', '\r', '\n', ',', ';':
 			continue
 		default:
 			// transition to being in a value
@@ -219,7 +219,7 @@ func lexSpace(l *Lexer) tokenStateFn {
 func lexVal(l *Lexer) tokenStateFn {
 	l.start = l.pos
 	switch r := l.next(); {
-	case isAlphaNumeric(r) || isWildcard(r) || isEscape(r) || r == '%':
+	case isAlphaNumeric(r) || isWildcard(r) || isEscape(r) || isLiteralChar(r):
 		l.backup()
 		return lexWord
 	case isSymbol(r):
@@ -287,7 +287,7 @@ func lexWord(l *Lexer) tokenStateFn {
 loop:
 	for {
 		switch r := l.next(); {
-		case isAlphaNumeric(r) || isWildcard(r) || r == '.' || r == '-' || r == '%':
+		case isAlphaNumeric(r) || isWildcard(r) || isLiteralChar(r) || r == '.' || r == '-':
 			// do nothing
 		case isEscape(r):
 			l.next() // just ignore the next character
@@ -391,6 +391,13 @@ func isSpace(r rune) bool {
 // isEscape checks whether the character is an escape character
 func isEscape(r rune) bool {
 	return r == '\\'
+}
+
+// isLiteralChar checks whether the character is allowed as part of a literal value
+// but is not alphanumeric, wildcard, or escape. These characters have no special
+// meaning in Lucene syntax and commonly appear in real-world search terms.
+func isLiteralChar(r rune) bool {
+	return r == '%' || r == '@' || r == '#' || r == '$'
 }
 
 // isSymbol checks whether the run is one of the reserved symbols

--- a/internal/lex/lext_test.go
+++ b/internal/lex/lext_test.go
@@ -265,6 +265,58 @@ func TestLex(t *testing.T) {
 				tok(TLiteral, "100%"),
 			},
 		},
+		"comma_treated_as_separator": {
+			in: "a, b",
+			expected: []Token{
+				tok(TLiteral, "a"),
+				tok(TLiteral, "b"),
+			},
+		},
+		"comma_between_terms": {
+			in: `\[*\] Actual go routines \[*\], allocated objects`,
+			expected: []Token{
+				tok(TLiteral, `\[*\]`),
+				tok(TLiteral, "Actual"),
+				tok(TLiteral, "go"),
+				tok(TLiteral, "routines"),
+				tok(TLiteral, `\[*\]`),
+				tok(TLiteral, "allocated"),
+				tok(TLiteral, "objects"),
+			},
+		},
+		"semicolon_treated_as_separator": {
+			in: "a; b",
+			expected: []Token{
+				tok(TLiteral, "a"),
+				tok(TLiteral, "b"),
+			},
+		},
+		"at_sign_in_literal": {
+			in: "user@example.com",
+			expected: []Token{
+				tok(TLiteral, "user@example.com"),
+			},
+		},
+		"at_sign_field_value": {
+			in: "email:user@example.com",
+			expected: []Token{
+				tok(TLiteral, "email"),
+				tok(TColon, ":"),
+				tok(TLiteral, "user@example.com"),
+			},
+		},
+		"hash_in_literal": {
+			in: "#channel",
+			expected: []Token{
+				tok(TLiteral, "#channel"),
+			},
+		},
+		"dollar_in_literal": {
+			in: "$variable",
+			expected: []Token{
+				tok(TLiteral, "$variable"),
+			},
+		},
 	}
 
 	for name, tc := range tcs {
@@ -311,7 +363,7 @@ func finalizeExpected(in string, tokens []Token) (out []Token) {
 
 func movePastWhitespace(in string) (count int) {
 	for _, c := range in {
-		if !isSpace(c) {
+		if !isSpace(c) && c != ',' && c != ';' {
 			return count
 		}
 		count++

--- a/parse_test.go
+++ b/parse_test.go
@@ -643,6 +643,33 @@ func TestParseLucene(t *testing.T) {
 			input: "50%done",
 			want:  expr.Lit("50%done"),
 		},
+		// comma and semicolon are not Lucene operators and should be treated
+		// as whitespace separators (issue #48).
+		"comma_as_separator": {
+			input: "a, b",
+			want:  expr.AND(expr.Lit("a"), expr.Lit("b")),
+		},
+		"comma_between_multiple_terms": {
+			input: "a, b, c",
+			want:  expr.AND(expr.AND(expr.Lit("a"), expr.Lit("b")), expr.Lit("c")),
+		},
+		"semicolon_as_separator": {
+			input: "a; b",
+			want:  expr.AND(expr.Lit("a"), expr.Lit("b")),
+		},
+		// @, #, $ are valid literal characters.
+		"at_sign_in_literal": {
+			input: "user@example.com",
+			want:  expr.Lit("user@example.com"),
+		},
+		"hash_in_literal": {
+			input: "#channel",
+			want:  expr.Lit("#channel"),
+		},
+		"dollar_in_literal": {
+			input: "$var",
+			want:  expr.Lit("$var"),
+		},
 	}
 
 	for name, tc := range tcs {
@@ -853,4 +880,28 @@ func FuzzParse(f *testing.F) {
 	f.Fuzz(func(t *testing.T, in string) {
 		_, _ = Parse(in)
 	})
+}
+
+// TestParseSeparatorCharacters validates that commas, semicolons, and other
+// non-Lucene characters do not cause parse errors (issue #48).
+func TestParseSeparatorCharacters(t *testing.T) {
+	inputs := map[string]string{
+		"comma_from_issue_48":  `\[*\] Actual go routines \[*\], allocated objects in bytes \[*\], allocated objects \[*\]`,
+		"semicolons":           `a; b; c`,
+		"mixed_separators":     `a, b; c`,
+		"email_address":        `user@example.com`,
+		"hash_tag":             `#channel`,
+		"dollar_variable":      `$var`,
+		"field_with_at":        `recipient:user@example.com`,
+		"field_with_hash":      `tag:#important`,
+	}
+
+	for name, input := range inputs {
+		t.Run(name, func(t *testing.T) {
+			_, err := Parse(input)
+			if err != nil {
+				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
 }

--- a/postgresql_test.go
+++ b/postgresql_test.go
@@ -365,6 +365,23 @@ func TestPostgresSQLEndToEnd(t *testing.T) {
 			input: `k1:v1 -(k2:v2 OR k3:v3)`,
 			want:  `("k1" = 'v1') AND (NOT(("k2" = 'v2') OR ("k3" = 'v3')))`,
 		},
+		"comma_separated_terms_with_default_field": {
+			input:        "foo, bar, baz",
+			want:         `(("default" = 'foo') AND ("default" = 'bar')) AND ("default" = 'baz')`,
+			defaultField: "default",
+		},
+		"comma_separated_field_values": {
+			input: "a:b, c:d",
+			want:  `("a" = 'b') AND ("c" = 'd')`,
+		},
+		"semicolon_separated_field_values": {
+			input: "a:b; c:d",
+			want:  `("a" = 'b') AND ("c" = 'd')`,
+		},
+		"email_field_value": {
+			input: "email:user@example.com",
+			want:  `"email" = 'user@example.com'`,
+		},
 	}
 
 	for name, tc := range tcs {


### PR DESCRIPTION
Fixes #48.

The lexer didn't know what to do with commas so it generated an error token that the parser couldn't reduce. Since commas (and semicolons) have no meaning in Lucene syntax, the fix just treats them as whitespace in `lexSpace()`.

While I was in there, I also added `@`, `#`, and `$` as valid literal characters. These show up all the time in real queries (email addresses, Slack channels, variable names) and were hitting the same error path. Consolidated them with `%` into an `isLiteralChar()` helper.

`&` and `|` are left alone `&&`/`||` mean AND/OR in Lucene, so handling those properly would need multi-character token support, which is a separate thing.