### PR TITLE
fix: honor backslash-escaped quotes inside phrases

### DIFF
--- a/internal/lex/lex.go
+++ b/internal/lex/lex.go
@@ -251,8 +251,10 @@ func lexPhrase(l *Lexer) tokenStateFn {
 
 	for {
 		switch r := l.next(); {
-		case isAlphaNumeric(r) || isWildcard(r) || isEscape(r):
+		case isAlphaNumeric(r) || isWildcard(r):
 			// do nothing
+		case isEscape(r):
+			l.next() // consume the escaped char so \" stays inside the phrase
 		case r == ' ' || r == '\t' || r == '\r' || r == '\n':
 			// do nothing
 		case r == open:

--- a/internal/lex/lext_test.go
+++ b/internal/lex/lext_test.go
@@ -238,6 +238,30 @@ func TestLex(t *testing.T) {
 				tok(TQuoted, "\"works well\""),
 			},
 		},
+		"escaped_double_quote_stays_in_phrase": {
+			in: `"foo\"bar"`,
+			expected: []Token{
+				tok(TQuoted, `"foo\"bar"`),
+			},
+		},
+		"escaped_single_quote_stays_in_phrase": {
+			in: `'foo\'bar'`,
+			expected: []Token{
+				tok(TQuoted, `'foo\'bar'`),
+			},
+		},
+		"escaped_backslash_before_closing_quote": {
+			in: `"foo\\"`,
+			expected: []Token{
+				tok(TQuoted, `"foo\\"`),
+			},
+		},
+		"unterminated_quote_with_trailing_backslash": {
+			in: `"foo\`,
+			expected: []Token{
+				tok(TErr, "unterminated quote"),
+			},
+		},
 		"percent_sign_standalone": {
 			in: "100%",
 			expected: []Token{

--- a/mysql_test.go
+++ b/mysql_test.go
@@ -263,8 +263,8 @@ func TestMySQLSQLEndToEnd(t *testing.T) {
 			want:  "(`a` > 10) AND (NOT(`b` <= -20))",
 		},
 		"escape_quotes": {
-			input: "a:'b'",
-			want:  "`a` = '''b'''",
+			input: `a:'it\'s here'`,
+			want:  "`a` = 'it''s here'",
 		},
 		"name_starts_with_number": {
 			input: "1a:b",
@@ -749,10 +749,10 @@ func TestMySQLParameterizedSQLEndToEnd(t *testing.T) {
 			wantStr:    "(`a` > ?) AND (NOT(`b` <= ?))",
 			wantParams: []any{10, -20},
 		},
-		"escape_quotes": {
-			input:      "a:'b'",
+		"phrase_quote_unescaping": {
+			input:      `a:'it\'s here'`,
 			wantStr:    "`a` = ?",
-			wantParams: []any{"'b'"},
+			wantParams: []any{"it's here"},
 		},
 		"name_starts_with_number": {
 			input:      "1a:b",

--- a/parse.go
+++ b/parse.go
@@ -267,8 +267,15 @@ func (p *parser) reduce() (err error) {
 }
 
 func parseLiteral(token lex.Token) (e any, err error) {
-	// if it is a quote then remove escape
 	if token.Typ == lex.TQuoted {
+		// double-quoted phrases: strip the delimiters and unescape \" and \\.
+		if token.Val[0] == '"' {
+			return expr.Lit(unescapePhrase(token.Val)), nil
+		}
+		// single-quoted phrases keep their delimiters in the literal value
+		// today (see the "escape_quotes" driver tests) - that asymmetry with
+		// double-quoted phrases is a separate, pre-existing issue and is left
+		// untouched here.
 		return expr.Lit(strings.ReplaceAll(token.Val, "\"", "")), nil
 	}
 
@@ -307,4 +314,23 @@ func parseLiteral(token lex.Token) (e any, err error) {
 	}
 
 	return expr.Lit(token.Val), nil
+}
+
+// unescapePhrase strips the surrounding quote delimiters off a TQuoted token's
+// raw value and unescapes only the delimiter itself and a literal backslash,
+// e.g. \" -> " and \\ -> \. Any other backslash sequence is left untouched so
+// that phrase content like a Windows path (C:\temp) round-trips unchanged.
+func unescapePhrase(val string) string {
+	delim := val[0]
+	inner := val[1 : len(val)-1]
+
+	var b strings.Builder
+	b.Grow(len(inner))
+	for i := 0; i < len(inner); i++ {
+		if inner[i] == '\\' && i+1 < len(inner) && (inner[i+1] == delim || inner[i+1] == '\\') {
+			i++
+		}
+		b.WriteByte(inner[i])
+	}
+	return b.String()
 }

--- a/parse.go
+++ b/parse.go
@@ -267,16 +267,9 @@ func (p *parser) reduce() (err error) {
 }
 
 func parseLiteral(token lex.Token) (e any, err error) {
+	// strip the delimiters (either " or ') and unescape \<delim> and \\.
 	if token.Typ == lex.TQuoted {
-		// double-quoted phrases: strip the delimiters and unescape \" and \\.
-		if token.Val[0] == '"' {
-			return expr.Lit(unescapePhrase(token.Val)), nil
-		}
-		// single-quoted phrases keep their delimiters in the literal value
-		// today (see the "escape_quotes" driver tests) - that asymmetry with
-		// double-quoted phrases is a separate, pre-existing issue and is left
-		// untouched here.
-		return expr.Lit(strings.ReplaceAll(token.Val, "\"", "")), nil
+		return expr.Lit(unescapePhrase(token.Val)), nil
 	}
 
 	// bare `null` keyword (case-insensitive) -> typed null literal.

--- a/parse_test.go
+++ b/parse_test.go
@@ -255,11 +255,21 @@ func TestParseLucene(t *testing.T) {
 			input: `name:"foo\"bar"`,
 			want:  expr.Eq("name", `foo"bar`),
 		},
-		"single_quoted_phrase_escaping_stays_unfixed": {
-			// single-quoted phrases don't strip their delimiters or unescape
-			// today - only double-quoted phrases are fixed by this change.
+		"single_quoted_phrase_plain": {
+			input: `name:'foo bar'`,
+			want:  expr.Eq("name", `foo bar`),
+		},
+		"single_quoted_phrase_with_escaped_quote": {
 			input: `name:'foo\'bar'`,
-			want:  expr.Eq("name", `'foo\'bar'`),
+			want:  expr.Eq("name", `foo'bar`),
+		},
+		"single_quoted_phrase_with_escaped_backslash": {
+			input: `name:'foo\\bar'`,
+			want:  expr.Eq("name", `foo\bar`),
+		},
+		"single_quoted_phrase_preserves_unescaped_backslash": {
+			input: `name:'C:\temp'`,
+			want:  expr.Eq("name", `C:\temp`),
 		},
 		"phrase_with_escaped_backslash": {
 			input: `name:"foo\\bar"`,
@@ -964,14 +974,14 @@ func FuzzParse(f *testing.F) {
 // non-Lucene characters do not cause parse errors (issue #48).
 func TestParseSeparatorCharacters(t *testing.T) {
 	inputs := map[string]string{
-		"comma_from_issue_48":  `\[*\] Actual go routines \[*\], allocated objects in bytes \[*\], allocated objects \[*\]`,
-		"semicolons":           `a; b; c`,
-		"mixed_separators":     `a, b; c`,
-		"email_address":        `user@example.com`,
-		"hash_tag":             `#channel`,
-		"dollar_variable":      `$var`,
-		"field_with_at":        `recipient:user@example.com`,
-		"field_with_hash":      `tag:#important`,
+		"comma_from_issue_48": `\[*\] Actual go routines \[*\], allocated objects in bytes \[*\], allocated objects \[*\]`,
+		"semicolons":          `a; b; c`,
+		"mixed_separators":    `a, b; c`,
+		"email_address":       `user@example.com`,
+		"hash_tag":            `#channel`,
+		"dollar_variable":     `$var`,
+		"field_with_at":       `recipient:user@example.com`,
+		"field_with_hash":     `tag:#important`,
 	}
 
 	for name, input := range inputs {
@@ -988,8 +998,10 @@ func TestParseSeparatorCharacters(t *testing.T) {
 // an escaped quote survives Parse -> String() -> Parse unchanged (issue #59).
 func TestQuotedPhraseRoundTrip(t *testing.T) {
 	tcs := map[string]string{
-		"escaped_quote":            `name:"foo\"bar"`,
-		"escaped_quote_with_space": `name:"foo\"bar baz"`,
+		"escaped_quote":                   `name:"foo\"bar"`,
+		"escaped_quote_with_space":        `name:"foo\"bar baz"`,
+		"escaped_single_quote_no_space":   `name:'it\'s'`,
+		"escaped_single_quote_with_space": `name:'it\'s here'`,
 	}
 
 	for name, input := range tcs {

--- a/parse_test.go
+++ b/parse_test.go
@@ -273,6 +273,16 @@ func TestParseLucene(t *testing.T) {
 			input: `name:"acme\" OR admin:true OR name:\"x"`,
 			want:  expr.Eq("name", `acme" OR admin:true OR name:"x`),
 		},
+		"phrase_escaped_backslash_at_boundary": {
+			// the escaped-backslash pair sits immediately before the real
+			// closing quote, pinning the off-by-one at the end of the scan.
+			input: `name:"foo\\"`,
+			want:  expr.Eq("name", `foo\`),
+		},
+		"phrase_with_multibyte_utf8_near_escape": {
+			input: `name:"café\"日本語"`,
+			want:  expr.Eq("name", `café"日本語`),
+		},
 		"boost_key_value": {
 			input: "a:b^2 AND foo",
 			want: expr.AND(
@@ -969,6 +979,34 @@ func TestParseSeparatorCharacters(t *testing.T) {
 			_, err := Parse(input)
 			if err != nil {
 				t.Fatalf("expected no error, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestQuotedPhraseRoundTrip verifies that a double-quoted phrase containing
+// an escaped quote survives Parse -> String() -> Parse unchanged (issue #59).
+func TestQuotedPhraseRoundTrip(t *testing.T) {
+	tcs := map[string]string{
+		"escaped_quote":            `name:"foo\"bar"`,
+		"escaped_quote_with_space": `name:"foo\"bar baz"`,
+	}
+
+	for name, input := range tcs {
+		t.Run(name, func(t *testing.T) {
+			first, err := Parse(input)
+			if err != nil {
+				t.Fatalf("expected no error parsing %q, got: %v", input, err)
+			}
+
+			rendered := first.String()
+			second, err := Parse(rendered)
+			if err != nil {
+				t.Fatalf("expected no error re-parsing rendered form %q, got: %v", rendered, err)
+			}
+
+			if !reflect.DeepEqual(first, second) {
+				t.Fatalf(errTemplate, "round trip through String() changed the expression", first, second)
 			}
 		})
 	}

--- a/parse_test.go
+++ b/parse_test.go
@@ -994,14 +994,16 @@ func TestParseSeparatorCharacters(t *testing.T) {
 	}
 }
 
-// TestQuotedPhraseRoundTrip verifies that a double-quoted phrase containing
-// an escaped quote survives Parse -> String() -> Parse unchanged (issue #59).
+// TestQuotedPhraseRoundTrip verifies that a phrase containing an escaped
+// quote (double- or single-delimited) survives Parse -> String() -> Parse
+// unchanged (issue #59).
 func TestQuotedPhraseRoundTrip(t *testing.T) {
 	tcs := map[string]string{
 		"escaped_quote":                   `name:"foo\"bar"`,
 		"escaped_quote_with_space":        `name:"foo\"bar baz"`,
 		"escaped_single_quote_no_space":   `name:'it\'s'`,
 		"escaped_single_quote_with_space": `name:'it\'s here'`,
+		"escaped_backslash_with_space":    `name:"foo bar\\"`,
 	}
 
 	for name, input := range tcs {

--- a/parse_test.go
+++ b/parse_test.go
@@ -251,6 +251,28 @@ func TestParseLucene(t *testing.T) {
 			input: `foo\ bar:b`,
 			want:  expr.Eq(`foo bar`, "b"),
 		},
+		"phrase_with_escaped_double_quote": {
+			input: `name:"foo\"bar"`,
+			want:  expr.Eq("name", `foo"bar`),
+		},
+		"single_quoted_phrase_escaping_stays_unfixed": {
+			// single-quoted phrases don't strip their delimiters or unescape
+			// today - only double-quoted phrases are fixed by this change.
+			input: `name:'foo\'bar'`,
+			want:  expr.Eq("name", `'foo\'bar'`),
+		},
+		"phrase_with_escaped_backslash": {
+			input: `name:"foo\\bar"`,
+			want:  expr.Eq("name", `foo\bar`),
+		},
+		"phrase_preserves_unescaped_backslash": {
+			input: `name:"C:\temp"`,
+			want:  expr.Eq("name", `C:\temp`),
+		},
+		"phrase_escaped_quote_prevents_injection": {
+			input: `name:"acme\" OR admin:true OR name:\"x"`,
+			want:  expr.Eq("name", `acme" OR admin:true OR name:"x`),
+		},
 		"boost_key_value": {
 			input: "a:b^2 AND foo",
 			want: expr.AND(

--- a/pkg/lucene/expr/expression_test.go
+++ b/pkg/lucene/expr/expression_test.go
@@ -399,6 +399,22 @@ func TestNullOperatorPlumbing(t *testing.T) {
 	}
 }
 
+// TestRenderLiteralQuoteEscaping pins that only a plain Literal escapes an
+// embedded quote when rendered back to Lucene syntax (issue #59); Wild and
+// Regexp keep their pre-existing, unescaped, space-only quoting since their
+// raw text isn't phrase-delimiter-escaped.
+func TestRenderLiteralQuoteEscaping(t *testing.T) {
+	if got, want := Lit(`foo"bar`).String(), `"foo\"bar"`; got != want {
+		t.Fatalf("Lit(%q).String() = %q, want %q", `foo"bar`, got, want)
+	}
+	if got, want := WILD(`fo"o*`).String(), `fo"o*`; got != want {
+		t.Fatalf("WILD(%q).String() = %q, want %q", `fo"o*`, got, want)
+	}
+	if got, want := REGEXP(`/fo"o/`).String(), `/fo"o/`; got != want {
+		t.Fatalf("REGEXP(%q).String() = %q, want %q", `/fo"o/`, got, want)
+	}
+}
+
 func TestNullValidation(t *testing.T) {
 	if err := Validate(NULL()); err != nil {
 		t.Fatalf("Validate(NULL()) returned err: %v", err)

--- a/pkg/lucene/expr/expression_test.go
+++ b/pkg/lucene/expr/expression_test.go
@@ -410,6 +410,13 @@ func TestRenderLiteralQuoteEscaping(t *testing.T) {
 	if got, want := Lit(`it's`).String(), `"it's"`; got != want {
 		t.Fatalf("Lit(%q).String() = %q, want %q", `it's`, got, want)
 	}
+	// a space alone triggers the same quote+escape branch as an embedded
+	// quote, so a literal with both a space and a trailing backslash must
+	// still have the backslash escaped - otherwise it renders as `"foo bar\"`,
+	// which the lexer reads as an escaped closing quote and fails to re-parse.
+	if got, want := Lit(`foo bar\`).String(), `"foo bar\\"`; got != want {
+		t.Fatalf("Lit(%q).String() = %q, want %q", `foo bar\`, got, want)
+	}
 	if got, want := WILD(`fo"o*`).String(), `fo"o*`; got != want {
 		t.Fatalf("WILD(%q).String() = %q, want %q", `fo"o*`, got, want)
 	}

--- a/pkg/lucene/expr/expression_test.go
+++ b/pkg/lucene/expr/expression_test.go
@@ -407,6 +407,9 @@ func TestRenderLiteralQuoteEscaping(t *testing.T) {
 	if got, want := Lit(`foo"bar`).String(), `"foo\"bar"`; got != want {
 		t.Fatalf("Lit(%q).String() = %q, want %q", `foo"bar`, got, want)
 	}
+	if got, want := Lit(`it's`).String(), `"it's"`; got != want {
+		t.Fatalf("Lit(%q).String() = %q, want %q", `it's`, got, want)
+	}
 	if got, want := WILD(`fo"o*`).String(), `fo"o*`; got != want {
 		t.Fatalf("WILD(%q).String() = %q, want %q", `fo"o*`, got, want)
 	}

--- a/pkg/lucene/expr/renderer.go
+++ b/pkg/lucene/expr/renderer.go
@@ -144,12 +144,15 @@ func renderLiteral(e *Expression, verbose bool) string {
 	}
 
 	// only a plain Literal can hold a raw quote character today (produced by
-	// unescaping \" inside a double-quoted phrase), so only escape quotes for
-	// those. Wild and Regexp also render through here but keep their prior,
+	// unescaping \" or \' inside a phrase), so only escape/quote-guard those.
+	// Wild and Regexp also render through here but keep their prior,
 	// space-only quoting - their raw text isn't phrase-delimiter-escaped and
 	// wrapping it in quotes here would change what it re-parses as.
 	s, isStr := e.Left.(string)
-	if isStr && e.Op == Literal && strings.ContainsAny(s, ` "`) {
+	if isStr && e.Op == Literal && strings.ContainsAny(s, ` "'`) {
+		// the rendered phrase always uses " as its delimiter, so only " (and
+		// the backslash that would otherwise escape it) need escaping here -
+		// a bare ' just needs the value quoted so it isn't lexed as a word.
 		escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(s)
 		return fmt.Sprintf(`"%s"`, escaped)
 	}

--- a/pkg/lucene/expr/renderer.go
+++ b/pkg/lucene/expr/renderer.go
@@ -144,8 +144,9 @@ func renderLiteral(e *Expression, verbose bool) string {
 	}
 
 	s, isStr := e.Left.(string)
-	if isStr && strings.ContainsAny(s, " ") {
-		return fmt.Sprintf(`"%s"`, s)
+	if isStr && strings.ContainsAny(s, ` "`) {
+		escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(s)
+		return fmt.Sprintf(`"%s"`, escaped)
 	}
 
 	return fmt.Sprintf("%v", e.Left)

--- a/pkg/lucene/expr/renderer.go
+++ b/pkg/lucene/expr/renderer.go
@@ -143,10 +143,18 @@ func renderLiteral(e *Expression, verbose bool) string {
 		return fmt.Sprintf("%s(%#v)", toString[e.Op], e.Left)
 	}
 
+	// only a plain Literal can hold a raw quote character today (produced by
+	// unescaping \" inside a double-quoted phrase), so only escape quotes for
+	// those. Wild and Regexp also render through here but keep their prior,
+	// space-only quoting - their raw text isn't phrase-delimiter-escaped and
+	// wrapping it in quotes here would change what it re-parses as.
 	s, isStr := e.Left.(string)
-	if isStr && strings.ContainsAny(s, ` "`) {
+	if isStr && e.Op == Literal && strings.ContainsAny(s, ` "`) {
 		escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(s)
 		return fmt.Sprintf(`"%s"`, escaped)
+	}
+	if isStr && strings.ContainsAny(s, " ") {
+		return fmt.Sprintf(`"%s"`, s)
 	}
 
 	return fmt.Sprintf("%v", e.Left)

--- a/postgresql_test.go
+++ b/postgresql_test.go
@@ -267,8 +267,8 @@ func TestPostgresSQLEndToEnd(t *testing.T) {
 			want:  `("a" > 10) AND (NOT("b" <= -20))`,
 		},
 		"escape_quotes": {
-			input: "a:'b'",
-			want:  `"a" = '''b'''`,
+			input: `a:'it\'s here'`,
+			want:  `"a" = 'it''s here'`,
 		},
 		"name_starts_with_number": {
 			input: "1a:b",
@@ -792,10 +792,10 @@ func TestPostgresParameterizedSQLEndToEnd(t *testing.T) {
 			wantStr:    `("a" > $1) AND (NOT("b" <= $2))`,
 			wantParams: []any{10, -20},
 		},
-		"escape_quotes": {
-			input:      "a:'b'",
+		"phrase_quote_unescaping": {
+			input:      `a:'it\'s here'`,
 			wantStr:    `"a" = $1`,
-			wantParams: []any{"'b'"},
+			wantParams: []any{"it's here"},
 		},
 		"name_starts_with_number": {
 			input:      "1a:b",

--- a/sqlite_test.go
+++ b/sqlite_test.go
@@ -263,8 +263,8 @@ func TestSQLiteSQLEndToEnd(t *testing.T) {
 			want:  `("a" > 10) AND (NOT("b" <= -20))`,
 		},
 		"escape_quotes": {
-			input: "a:'b'",
-			want:  `"a" = '''b'''`,
+			input: `a:'it\'s here'`,
+			want:  `"a" = 'it''s here'`,
 		},
 		"name_starts_with_number": {
 			input: "1a:b",
@@ -784,10 +784,10 @@ func TestSQLiteParameterizedSQLEndToEnd(t *testing.T) {
 			wantStr:    `("a" > ?) AND (NOT("b" <= ?))`,
 			wantParams: []any{10, -20},
 		},
-		"escape_quotes": {
-			input:      "a:'b'",
+		"phrase_quote_unescaping": {
+			input:      `a:'it\'s here'`,
 			wantStr:    `"a" = ?`,
-			wantParams: []any{"'b'"},
+			wantParams: []any{"it's here"},
 		},
 		"name_starts_with_number": {
 			input:      "1a:b",


### PR DESCRIPTION
Fixes #59.

A double-quoted phrase like `name:"foo\"bar"` couldn't represent a literal quote. `lexPhrase` closed the phrase on the first quote it saw, even a backslash-escaped one, so the escape was silently ignored and the rest of the input got lexed as unrelated tokens. That also meant there was no safe way to escape a quote before interpolating an untrusted value into a phrase, so a raw `"` in a value could break out of the phrase and inject arbitrary query structure.

## What changes

`lexPhrase` now consumes the character after a backslash, the same way `lexWord` and `lexRegexp` already do, so `\"` stays inside the phrase instead of closing it. `parseLiteral` no longer strips every quote character out of a quoted token; for double-quoted phrases specifically it strips the surrounding delimiters and unescapes `\"` and `\\`, leaving any other backslash alone so something like `"C:\temp"` still comes through as a literal backslash instead of silently losing it.

## Examples

```
name:"foo bar"                            ->  name:"foo bar"                (unchanged)

name:"foo\"bar"
  before  ->  error parsing, no items left to reduce
  after   ->  name:"foo\"bar"             (value is foo"bar)

name:"acme\" OR admin:true OR name:\"x"
  before  ->  error parsing, no items left to reduce
  after   ->  name:"acme\" OR admin:true OR name:\"x"   (one literal value, no injected clause)
```

## Bundled fixes

Fixing the parse side exposed a matching bug on the render side. A literal can now legitimately hold a raw quote, but `renderLiteral` only wrapped a value in quotes when it contained a space and never escaped anything, so `Parse(...).String()` on one of these values produced text that wouldn't re-parse. I fixed `renderLiteral` to also quote and escape when the value contains a quote, scoped to plain literals only. `Wild` and `Regexp` render through the same function but keep their old space-only quoting, since their raw text was never phrase-delimiter-escaped and quoting it here would change what it re-parses as.

Single-quoted phrases had the same bug, but worse: they never stripped their own delimiters at all, escaped or not. `name:'foo bar'` parsed to the literal value `'foo bar'`, quotes included, for any value. That's not a documented feature (the README only covers double-quoted phrases), and the `escape_quotes` driver tests that looked like they pinned this as intentional turn out to just be testing SQL-level quote escaping and happened to lean on the bug to get a quote character into the value. `parseLiteral` now handles both delimiters the same way, and I updated those tests to exercise the escaping they're named for without depending on the bug. `renderLiteral` needed the same bare-quote handling extended to `'`, since a literal can now hold a lone apostrophe that would otherwise get misread as opening a new phrase when serialized back out.

## End-user effect

- `field:"value with a literal \" in it"` now works instead of erroring or truncating.
- `field:'value with a literal \' in it'` now works the same way.
- `field:'plain single quoted value'` now returns the value `plain single quoted value` instead of `'plain single quoted value'` with the quotes still attached. Anyone currently working around that by stripping the quotes themselves can drop the workaround; anyone unknowingly relying on the quotes being there will see their query results change.
- `Expression.String()` round-trips these values back into valid Lucene syntax instead of producing text that fails to re-parse or silently loses part of the value.